### PR TITLE
Improve memory management of BSK models

### DIFF
--- a/bsk_rl/envs/GeneralSatelliteTasking/gym_env.py
+++ b/bsk_rl/envs/GeneralSatelliteTasking/gym_env.py
@@ -118,9 +118,7 @@ class GeneralSatelliteTasking(Env):
         self.env_features.reset()
         self.data_manager.reset()
 
-        # Destroy cross references to actually delete the simulator.
-        for satellite in self.satellites:
-            satellite.delete_simulator()
+        # Explicitly delete the Basilisk simulation before creating a new one.
         self.delete_simulator()
 
         for satellite in self.satellites:
@@ -147,17 +145,14 @@ class GeneralSatelliteTasking(Env):
         return observation, info
 
     def delete_simulator(self):
-        """Delete cross-references to simulator objects"""
-
-        for attr in [
-            "simulator.environment.simulator",
-            "simulator.environment",
-            "simulator",
-        ]:
-            try:
-                delattr(self, attr)
-            except AttributeError:
-                pass
+        """Delete Basilisk objects. Only self.simulator contains strong references to BSK models, so deleting it will
+        delete all Basilisk objects. Enable MEMORY_LEAK_CHECKING in bsk_rl/envs/GeneralSatelliteTasking/utils/debug.py
+        to verify that the simulator, FSW, dynamics, and environment models are all deleted on reset.
+        """
+        try:
+            del self.simulator
+        except AttributeError:
+            pass
 
     def _get_obs(self) -> MultiSatObs:
         """Compose satellite observations into a single observation.

--- a/bsk_rl/envs/GeneralSatelliteTasking/simulation/simulator.py
+++ b/bsk_rl/envs/GeneralSatelliteTasking/simulation/simulator.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros as mc
 
+from bsk_rl.envs.GeneralSatelliteTasking.utils.debug import MEMORY_LEAK_CHECKING
+
 
 class Simulator(SimulationBaseClass.SimBaseClass):
     def __init__(
@@ -44,10 +46,9 @@ class Simulator(SimulationBaseClass.SimBaseClass):
         self.dynamics_list = {}
 
         for satellite in self.satellites:
-            self.dynamics_list[satellite.id] = satellite.set_dynamics(
-                self, self.sim_rate
-            )
-            self.fsw_list[satellite.id] = satellite.set_fsw(self, self.sim_rate)
+            satellite.set_simulator(self)
+            self.dynamics_list[satellite.id] = satellite.set_dynamics(self.sim_rate)
+            self.fsw_list[satellite.id] = satellite.set_fsw(self.sim_rate)
 
         self.InitializeSimulation()
         self.ConfigureStopTime(0)
@@ -81,3 +82,7 @@ class Simulator(SimulationBaseClass.SimBaseClass):
         )
         self.ConfigureStopTime(simulation_time)
         self.ExecuteSimulation()
+
+    def __del__(self):
+        if MEMORY_LEAK_CHECKING:
+            print("~~~ BSK SIMULATOR DELETED ~~~")

--- a/bsk_rl/envs/GeneralSatelliteTasking/utils/debug.py
+++ b/bsk_rl/envs/GeneralSatelliteTasking/utils/debug.py
@@ -1,0 +1,1 @@
+MEMORY_LEAK_CHECKING = False


### PR DESCRIPTION
Makes all BSK models have only a single strong reference in the simulator. Ensures that objects are cleanly deleted when intended (i.e. when `reset()` is called). Adds a `MEMORY_LEAK_CHECKING` flag to make memory leak debugging easier, which prints a message when BSK models are actually deleted.