### PR TITLE
Issue #25: Randomize epochs

### DIFF
--- a/bsk_rl/envs/GeneralSatelliteTasking/simulation/environment.py
+++ b/bsk_rl/envs/GeneralSatelliteTasking/simulation/environment.py
@@ -22,6 +22,7 @@ from bsk_rl.envs.GeneralSatelliteTasking.utils.functional import (
     collect_default_args,
     default_args,
 )
+from bsk_rl.envs.GeneralSatelliteTasking.utils.orbital import random_epoch
 
 bsk_path = __path__[0]
 
@@ -100,7 +101,7 @@ class BasicEnvironmentModel(EnvironmentModel):
         self._set_atmosphere_density_model(**kwargs)
         self._set_eclipse_object(**kwargs)
 
-    @default_args(utc_init="2021 MAY 04 07:47:48.965 (UTC)")
+    @default_args(utc_init=random_epoch)
     def _set_gravity_bodies(
         self, utc_init: str, priority: int = 1100, **kwargs
     ) -> None:

--- a/bsk_rl/envs/GeneralSatelliteTasking/utils/orbital.py
+++ b/bsk_rl/envs/GeneralSatelliteTasking/utils/orbital.py
@@ -47,6 +47,45 @@ def random_orbit(
     return oe
 
 
+def random_epoch(start: int = 2000, end: int = 2022):
+    """Generates a random epoch.
+
+    Args:
+        start: Initial year.
+        end: Final year.
+
+    Returns:
+        Epoch in `YYYY MMM DD HH:MM:SS.SSS (UTC)` format
+    """
+    year = np.random.randint(start, end)
+    month = np.random.choice(
+        [
+            "JAN",
+            "FEB",
+            "MAR",
+            "APR",
+            "MAY",
+            "JUN",
+            "JUL",
+            "AUG",
+            "SEP",
+            "OCT",
+            "NOV",
+            "DEC",
+        ]
+    )
+    day = np.random.randint(1, 28)  # Assume 28 days for simplicity
+    hours = np.random.randint(0, 23)
+    minutes = np.random.randint(0, 59)
+    seconds = np.random.randint(0, 59)
+    milliseconds = np.random.randint(0, 999)
+
+    # Combine the parts to form the datetime string
+    epoch = f"{year} {month} {day:02d} {hours:02d}:{minutes:02d}:{seconds:02d}.{milliseconds:03d} (UTC)"
+
+    return epoch
+
+
 def elevation(r_sat: np.ndarray, r_target: np.ndarray) -> np.ndarray:
     """Find the elevation angle from a target to a satellite
 


### PR DESCRIPTION
Adds a function to generate a random epoch between two chosen years. Assumes that all months have <=28 days.

@ai-in-aerospace Would this be more appropriate in the general utilities folder instead of the General Environment utilities folder (i.e., would other environments want to use this?)