### PR TITLE
Issue #16: Satellite cleanup

### DIFF
--- a/bsk_rl/envs/general_satellite_tasking/gym_env.py
+++ b/bsk_rl/envs/general_satellite_tasking/gym_env.py
@@ -219,6 +219,8 @@ class GeneralSatelliteTasking(Env):
         Returns:
             observation, reward, terminated, truncated, info
         """
+        if len(actions) != len(self.satellites):
+            raise ValueError("There must be the same number of actions and satellites")
         for satellite, action in zip(self.satellites, actions):
             satellite.info = []  # reset satellite info log
             satellite.set_action(action)
@@ -251,7 +253,7 @@ class GeneralSatelliteTasking(Env):
         info = self._get_info()
         return observation, reward, terminated, truncated, info
 
-    def render(self) -> None:
+    def render(self) -> None:  # pragma: no cover
         """No rendering implemented"""
         return None
 

--- a/bsk_rl/envs/general_satellite_tasking/scenario/communication.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/communication.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from itertools import combinations
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.envs.general_satellite_tasking.types import Satellite
 
 import numpy as np
@@ -21,7 +21,7 @@ class CommunicationMethod(ABC):
         """Called after simulator initialization"""
         pass
 
-    @abstractmethod
+    @abstractmethod  # pragma: no cover
     def _communication_pairs(self) -> list[tuple["Satellite", "Satellite"]]:
         """List pair of satellite that should share data"""
         pass

--- a/bsk_rl/envs/general_satellite_tasking/scenario/environment_features.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/environment_features.py
@@ -9,9 +9,7 @@ from Basilisk.utilities import orbitalMotion
 
 
 class EnvironmentFeatures(ABC):
-    def __init__(self) -> None:
-        """Base environment feature class"""
-        pass
+    """Base environment feature class"""
 
     def reset(self) -> None:
         """Reset environment features"""
@@ -82,6 +80,20 @@ class StaticTargets(EnvironmentFeatures):
             )
 
 
+def lla2ecef(lat: float, long: float, radius: float):
+    """
+    Args:
+        lat: [deg]
+        long: [deg]
+        radius: [any]
+    """
+    lat = np.radians(lat)
+    long = np.radians(long)
+    return radius * np.array(
+        [np.cos(lat) * np.cos(long), np.cos(lat) * np.sin(long), np.sin(lat)]
+    )
+
+
 class CityTargets(StaticTargets):
     def __init__(
         self,
@@ -120,15 +132,13 @@ class CityTargets(StaticTargets):
 
         for i in np.random.choice(self.n_select_from, self.n_targets, replace=False):
             city = cities.iloc[i]
-            lat = np.radians(city["lat"])
-            lng = np.radians(city["lng"])
-            location = self.radius * np.array(
-                [np.cos(lat) * np.cos(lng), np.cos(lat) * np.sin(lng), np.sin(lat)]
-            )
+            location = lla2ecef(city["lat"], city["lng"], self.radius)
             offset = np.random.normal(size=3)
-            offset *= self.location_offset / np.linalg.norm(offset)
+            offset /= np.linalg.norm(offset)
+            offset *= self.location_offset
             location += offset
-            location *= self.radius / np.linalg.norm(location)
+            location /= np.linalg.norm(location)
+            location *= self.radius
             self.targets.append(
                 Target(
                     name=city["city"].replace("'", ""),

--- a/bsk_rl/envs/general_satellite_tasking/scenario/sat_actions.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/sat_actions.py
@@ -80,7 +80,7 @@ class DiscreteSatAction(SatAction):
         return spaces.Discrete(len(self.action_list))
 
 
-def fsw_action_gen(fsw_action: str) -> DiscreteSatAction:
+def fsw_action_gen(fsw_action: str) -> type:
     @configurable
     class FSWAction(DiscreteSatAction):
         def __init__(self, *args, action_duration: float = 60.0, **kwargs) -> None:

--- a/bsk_rl/envs/general_satellite_tasking/scenario/sat_observations.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/sat_observations.py
@@ -57,7 +57,7 @@ class SatObservation(Satellite):
             return self.obs_dict
         elif self.obs_type is np.ndarray:
             return self.obs_ndarray
-        elif self.obs_list is list:
+        elif self.obs_type is list:
             return self.obs_list
         else:
             raise ValueError(f"Invalid observation type: {self.obs_type}")
@@ -174,7 +174,7 @@ class TargetState(SatObservation, ImagingSatellite):
         for i, target in enumerate(self.upcoming_targets(self.n_ahead_observe)):
             obs[f"tgt_value_{i}"] = target.priority
             loc_name = f"tgt_loc_{i}"
-            if loc_name != 1.0:
+            if self.location_norm != 1.0:
                 loc_name += "_normd"
             obs[loc_name] = target.location / self.location_norm
         return obs

--- a/bsk_rl/envs/general_satellite_tasking/simulation/environment.py
+++ b/bsk_rl/envs/general_satellite_tasking/simulation/environment.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Optional, Union
 from weakref import proxy
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.envs.general_satellite_tasking.types import Simulator
 
 import numpy as np
@@ -65,10 +65,10 @@ class EnvironmentModel(ABC):
         self._init_environment_objects(**kwargs)
 
     def __del__(self):
-        if MEMORY_LEAK_CHECKING:
+        if MEMORY_LEAK_CHECKING:  # pragma: no cover
             print("~~~ BSK ENVIRONMENT DELETED ~~~")
 
-    @abstractmethod
+    @abstractmethod  # pragma: no cover
     def _init_environment_objects(self, **kwargs) -> None:
         """Caller for all environment objects"""
         pass
@@ -222,7 +222,10 @@ class BasicEnvironmentModel(EnvironmentModel):
 
     def __del__(self) -> None:
         super().__del__()
-        self.gravFactory.unloadSpiceKernels()
+        try:
+            self.gravFactory.unloadSpiceKernels()
+        except AttributeError:
+            pass
 
 
 class GroundStationEnvModel(BasicEnvironmentModel):
@@ -272,10 +275,8 @@ class GroundStationEnvModel(BasicEnvironmentModel):
         self.groundLocationPlanetRadius = groundLocationPlanetRadius
         self.gsMinimumElevation = gsMinimumElevation
         self.gsMaximumRange = gsMaximumRange
-        for groundStationData in groundStationsData:
-            self._create_ground_station(
-                **groundStationData, priority=priority - len(self.groundStations)
-            )
+        for i, groundStationData in enumerate(groundStationsData):
+            self._create_ground_station(**groundStationData, priority=priority - i)
 
     def _create_ground_station(
         self,
@@ -290,7 +291,7 @@ class GroundStationEnvModel(BasicEnvironmentModel):
         Args:
             lat: Latitude [deg]
             long: Longitude [deg]
-            elev: Elemvation [m].
+            elev: Elevation [m].
             name: Ground station identifier.
             priority: Model priority.
         """

--- a/bsk_rl/envs/general_satellite_tasking/simulation/fsw.py
+++ b/bsk_rl/envs/general_satellite_tasking/simulation/fsw.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, Iterable
 from weakref import proxy
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.envs.general_satellite_tasking.types import (
         DynamicsModel,
         EnvironmentModel,
@@ -107,11 +107,10 @@ class FSWModel(ABC):
     def dynamics(self) -> "DynamicsModel":
         return self.satellite.dynamics
 
-    @abstractmethod
     def _make_task_list(self) -> list["Task"]:
-        pass
+        return []
 
-    @abstractmethod
+    @abstractmethod  # pragma: no cover
     def _set_messages(self) -> None:
         """Message setup after task creation"""
         pass
@@ -125,13 +124,13 @@ class FSWModel(ABC):
         return check_aliveness_checkers(self)
 
     def __del__(self):
-        if MEMORY_LEAK_CHECKING:
+        if MEMORY_LEAK_CHECKING:  # pragma: no cover
             print("~~~ BSK FSW DELETED ~~~")
 
 
 class Task(ABC):
     @property
-    @abstractmethod
+    @abstractmethod  # pragma: no cover
     def name(self) -> str:
         pass
 
@@ -154,12 +153,12 @@ class Task(ABC):
             taskPriority=self.priority,
         )
 
-    @abstractmethod
+    @abstractmethod  # pragma: no cover
     def create_module_data(self) -> None:
         """Create module data wrappers."""
         pass
 
-    @abstractmethod
+    @abstractmethod  # pragma: no cover
     def init_objects(self, **kwargs) -> None:
         """Initialize model parameters with satellite arguments/"""
         pass

--- a/bsk_rl/envs/general_satellite_tasking/simulation/simulator.py
+++ b/bsk_rl/envs/general_satellite_tasking/simulation/simulator.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.envs.general_satellite_tasking.types import (
         EnvironmentModel,
         Satellite,
@@ -84,5 +84,5 @@ class Simulator(SimulationBaseClass.SimBaseClass):
         self.ExecuteSimulation()
 
     def __del__(self):
-        if MEMORY_LEAK_CHECKING:
+        if MEMORY_LEAK_CHECKING:  # pragma: no cover
             print("~~~ BSK SIMULATOR DELETED ~~~")

--- a/bsk_rl/envs/general_satellite_tasking/utils/functional.py
+++ b/bsk_rl/envs/general_satellite_tasking/utils/functional.py
@@ -110,13 +110,6 @@ def aliveness_checker(func: Callable[..., bool]) -> Callable[..., bool]:
     return inner
 
 
-def is_property(obj: Any, attr_name: str) -> bool:
-    """Check if obj has an @property attr_name without calling it"""
-    cls = type(obj)
-    attribute = getattr(cls, attr_name, None)
-    return attribute is not None and isinstance(attribute, property)
-
-
 def check_aliveness_checkers(model: Any) -> bool:
     """Evaluate all functions with @aliveness_checker in a model
 
@@ -136,6 +129,13 @@ def check_aliveness_checkers(model: Any) -> bool:
         ):
             is_alive = is_alive and getattr(model, name)()
     return is_alive
+
+
+def is_property(obj: Any, attr_name: str) -> bool:
+    """Check if obj has an @property attr_name without calling it"""
+    cls = type(obj)
+    attribute = getattr(cls, attr_name, None)
+    return attribute is not None and isinstance(attribute, property)
 
 
 def configurable(cls):

--- a/examples/general_satellite_tasking/single_sat.py
+++ b/examples/general_satellite_tasking/single_sat.py
@@ -91,7 +91,7 @@ while True:
         if isinstance(msgs, list):
             for time, message in msgs:
                 msg_str = (
-                    f"\t<{'_'.join(sat.split('_')[0:-1])} at {time:.1f}>\t{message}",
+                    f"\t<{'_'.join(sat.split('_')[0:-1])} at {time:.1f}>\t{message}"
                 )
                 msg_list.append((time, msg_str))
     for time, message in sorted(msg_list):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "matplotlib",
         "numpy",
         "pandas",
+        "pytest",
         "requests",
         "scikit-learn",
         "scipy",

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_communication.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_communication.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.scenario.communication import (
+    CommunicationMethod,
+    FreeCommunication,
+    LOSCommunication,
+    MultiDegreeCommunication,
+    NoCommunication,
+)
+from bsk_rl.envs.general_satellite_tasking.simulation.dynamics import LOSCommDynModel
+
+
+@patch.multiple(CommunicationMethod, __abstractmethods__=set())
+class TestCommunicationMethod:
+    def test_communicate(self):
+        mock_sats = [MagicMock(), MagicMock()]
+        comms = CommunicationMethod(mock_sats)
+        comms._communication_pairs = MagicMock(
+            return_value=[(mock_sats[1], mock_sats[0])]
+        )
+        comms.communicate()
+        mock_sats[0].data_store.stage_communicated_data.assert_called_once_with(
+            mock_sats[1].data_store.data
+        )
+        mock_sats[1].data_store.stage_communicated_data.assert_called_once_with(
+            mock_sats[0].data_store.data
+        )
+        for sat in mock_sats:
+            sat.data_store.communication_update.assert_called_once()
+
+
+class TestNoCommunication:
+    def test_communicate(self):
+        mock_sats = [MagicMock(), MagicMock()]
+        comms = NoCommunication(mock_sats)
+        comms.communicate()
+        mock_sats[0].data_store.stage_communicated_data.assert_not_called()
+
+
+class TestFreeCommunication:
+    def test_communication_pairs(self):
+        mock_sats = [MagicMock() for i in range(4)]
+        comms = FreeCommunication(mock_sats)
+        pairs = comms._communication_pairs()
+        for sat1, sat2 in zip(mock_sats, mock_sats):
+            if sat1 != sat2:
+                assert (sat1, sat2) in pairs or (sat2, sat1) in pairs
+
+
+class TestLOSCommunication:
+    def test_dyn_model_check_valid(self):
+        mock_sats = [MagicMock(dyn_type=LOSCommDynModel) for i in range(3)]
+        LOSCommunication(mock_sats)
+
+    def test_dyn_model_check_invalid(self):
+        mock_sats = [MagicMock(dyn_type="NotLOSComm") for i in range(3)]
+        with pytest.raises(Exception):
+            LOSCommunication(mock_sats)
+
+    class LOSDynMock(MagicMock, LOSCommDynModel):
+        pass
+
+    def test_reset(self):
+        mock_sats = [
+            MagicMock(dyn_type=LOSCommDynModel, dynamics=self.LOSDynMock())
+            for i in range(3)
+        ]
+        comms = LOSCommunication(mock_sats)
+        comms.reset()
+        for sat1 in mock_sats:
+            assert sat1 in comms.los_logs
+            for sat2 in mock_sats:
+                if sat2 != sat1:
+                    assert (
+                        comms.los_logs[sat1][sat2]
+                        == sat1.dynamics.losComms.accessOutMsgs.__getitem__().recorder()
+                    )
+
+    @pytest.mark.parametrize(
+        "access1,access2,access",
+        [
+            ([0, 0], [0, 0], False),
+            ([0, 0], [0, 1], True),
+            ([1, 0], [0, 0], True),
+            ([1, 0], [0, 1], True),
+        ],
+    )
+    def test_communication_pairs(self, access1, access2, access):
+        mock_sats = [MagicMock(dyn_type=LOSCommDynModel) for i in range(2)]
+        comms = LOSCommunication(mock_sats)
+        comms.los_logs = {
+            mock_sats[0]: {mock_sats[1]: MagicMock(hasAccess=access1)},
+            mock_sats[1]: {mock_sats[0]: MagicMock(hasAccess=access2)},
+        }
+        if access:
+            assert len(comms._communication_pairs()) >= 1
+        else:
+            assert len(comms._communication_pairs()) == 0
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.communication.CommunicationMethod.communicate",
+        MagicMock(),
+    )
+    def test_communicate(self):
+        mock_sats = [MagicMock(dyn_type=LOSCommDynModel) for i in range(2)]
+        comms = LOSCommunication(mock_sats)
+        loggerA = MagicMock()
+        loggerB = MagicMock()
+        comms.los_logs = {
+            mock_sats[0]: {mock_sats[1]: loggerA},
+            mock_sats[1]: {mock_sats[0]: loggerB},
+        }
+        comms.communicate()
+        loggerA.clear.assert_called_once()
+        loggerB.clear.assert_called_once()
+
+
+class TestMultiDegreeCommunication:
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.communication.CommunicationMethod._communication_pairs"
+    )
+    def test_communication_pairs(self, mock_pairs):
+        mock_sats = [MagicMock() for i in range(6)]
+        mock_pairs.return_value = [
+            (mock_sats[0], mock_sats[1]),
+            (mock_sats[1], mock_sats[3]),
+            (mock_sats[3], mock_sats[4]),
+        ]
+        comms = MultiDegreeCommunication(mock_sats)
+        pairs = comms._communication_pairs()
+
+        assert (mock_sats[0], mock_sats[4]) in pairs
+        assert (mock_sats[0], mock_sats[5]) not in pairs

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_data.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_data.py
@@ -1,0 +1,163 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.scenario import data
+
+
+@patch.multiple(data.DataStore, __abstractmethods__=set())
+class TestDataStore:
+    def test_init(self):
+        # Essentially a smoketest
+        data.DataStore.DataType = MagicMock
+        ds = data.DataStore(MagicMock(), MagicMock())
+        ds._clear_logs()
+        ds._get_log_state()
+
+    def test_internal_update(self):
+        # Essentially a smoketest
+        data.DataStore.DataType = MagicMock
+        ds = data.DataStore(MagicMock(), MagicMock())
+        ds.internal_update()
+        ds.internal_update()
+
+    def test_communication_update(self):
+        data.DataStore.DataType = MagicMock
+        ds = data.DataStore(MagicMock(), MagicMock())
+        ds.data = []
+        ds.stage_communicated_data([100])
+        ds.communication_update()
+        assert ds.data == [100]
+
+
+@patch.multiple(data.DataManager, __abstractmethods__=set())
+class TestDataManager:
+    def test_reset(self):
+        data.DataManager.DataStore = MagicMock()
+        dm = data.DataManager(MagicMock())
+        dm.reset()
+        assert dm.cum_reward == 0
+
+    def test_create_data_store(self):
+        sat = MagicMock()
+        data.DataManager.DataStore = MagicMock(return_value="ds")
+        dm = data.DataManager(MagicMock())
+        dm.create_data_store(sat)
+        assert sat.data_store == "ds"
+
+    def test_reward(self):
+        dm = data.DataManager(MagicMock())
+        dm._calc_reward = MagicMock(return_value=10.0)
+        dm.cum_reward = 0
+        assert 10.0 == dm.reward({"new": "data"})
+        assert dm.cum_reward == 10.0
+
+
+class TestUniqueImageData:
+    def test_identify_duplicates(self):
+        dat1 = data.UniqueImageData([1, 1, 2])
+        assert dat1.duplicates == 1
+
+    def test_add_null(self):
+        dat1 = data.UniqueImageData()
+        dat2 = data.UniqueImageData()
+        dat = dat1 + dat2
+        assert dat.imaged == []
+        assert dat.duplicates == 0
+
+    def test_add_to_null(self):
+        dat1 = data.UniqueImageData(imaged=[1, 2])
+        dat2 = data.UniqueImageData()
+        dat = dat1 + dat2
+        assert dat.imaged == [1, 2]
+        assert dat.duplicates == 0
+
+    def test_add(self):
+        dat1 = data.UniqueImageData(imaged=[1, 2])
+        dat2 = data.UniqueImageData(imaged=[3, 4])
+        dat = dat1 + dat2
+        assert dat.imaged == [1, 2, 3, 4]
+        assert dat.duplicates == 0
+
+    def test_add_duplicates(self):
+        dat1 = data.UniqueImageData(imaged=[1, 2])
+        dat2 = data.UniqueImageData(imaged=[2, 3])
+        dat = dat1 + dat2
+        assert dat.imaged == [1, 2, 3]
+        assert dat.duplicates == 1
+
+    def test_add_duplicates_existing(self):
+        dat1 = data.UniqueImageData(imaged=[1, 2], duplicates=2)
+        dat2 = data.UniqueImageData(imaged=[2, 3], duplicates=3)
+        dat = dat1 + dat2
+        assert dat.imaged == [1, 2, 3]
+        assert dat.duplicates == 6
+
+
+class TestUniqueImageStore:
+    def test_get_log_state(self):
+        sat = MagicMock()
+        sat.dynamics.storageUnit.storageUnitDataOutMsg.read().storedData = [1, 2, 3]
+        ds = data.UniqueImageStore(MagicMock(), sat)
+        assert (ds._get_log_state() == np.array([1, 2, 3])).all()
+
+    @pytest.mark.parametrize(
+        "before,after,imaged",
+        [
+            ([0, 0, 0], [0, 0, 0], []),
+            ([0, 0, 1], [0, 0, 1], []),
+            ([0, 0, 1], [0, 0, 0], []),
+            ([0, 0, 0], [1, 0, 0], [0]),
+            ([0, 0, 0], [0, 1, 1], [1, 2]),
+        ],
+    )
+    def test_compare_log_states(self, before, after, imaged):
+        sat = MagicMock()
+        targets = [MagicMock() for i in range(3)]
+        ds = data.UniqueImageStore(MagicMock(), sat)
+        ds.env_knowledge = MagicMock(targets=targets)
+        message = sat.dynamics.storageUnit.storageUnitDataOutMsg
+        message.read.return_value.storedDataName.__getitem__.side_effect = (
+            lambda x: targets[x].id
+        )
+        dat = ds._compare_log_states(np.array(before), np.array(after))
+        assert len(dat.imaged) == len(imaged)
+        for i in imaged:
+            assert targets[i] in dat.imaged
+
+
+class TestUniqueImagingManager:
+    def test_calc_reward(self):
+        dm = data.UniqueImagingManager(MagicMock())
+        dm.data = data.UniqueImageData([])
+        reward = dm._calc_reward(
+            {
+                "sat1": data.UniqueImageData([MagicMock(priority=0.1)]),
+                "sat2": data.UniqueImageData([MagicMock(priority=0.2)]),
+            }
+        )
+        assert abs(reward - 0.3) < 1e-9
+
+    def test_calc_reward_existing(self):
+        tgt = MagicMock(priority=0.2)
+        dm = data.UniqueImagingManager(MagicMock())
+        dm.data = data.UniqueImageData([tgt])
+        reward = dm._calc_reward(
+            {
+                "sat1": data.UniqueImageData([MagicMock(priority=0.1)]),
+                "sat2": data.UniqueImageData([tgt]),
+            }
+        )
+        assert abs(reward - 0.1) < 1e-9
+
+    def test_calc_reward_custom_fn(self):
+        dm = data.UniqueImagingManager(MagicMock(), reward_fn=lambda x: 1 / x)
+        dm.data = data.UniqueImageData([])
+        reward = dm._calc_reward(
+            {
+                "sat1": data.UniqueImageData([MagicMock(priority=1)]),
+                "sat2": data.UniqueImageData([MagicMock(priority=2)]),
+            }
+        )
+        assert abs(reward - 1.5) < 1e-9

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_environment_features.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_environment_features.py
@@ -1,0 +1,147 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.scenario.environment_features import (
+    CityTargets,
+    StaticTargets,
+    Target,
+    lla2ecef,
+)
+
+
+class TestTarget:
+    T1a = Target("Boulder", [1, 2, 3], 1.0)
+    T1b = Target("Boulder", [1, 2, 3], 1.0)
+    T2 = Target("Pleasanton", np.array([0, 0, 0]), 0.5)
+
+    def test_id_unique(self):
+        assert self.T1a.id != self.T1b.id
+
+    def test_hash_unique(self):
+        assert hash(self.T1a) != hash(self.T1b)
+
+    def test_repr_(self):
+        assert self.T2.__repr__() == "Target(Pleasanton)"
+
+    def test_location_type(self):
+        assert np.all(self.T1a.location == np.array([1, 2, 3]))
+        assert not isinstance(self.T1a.location, list)
+        assert np.all(self.T2.location == np.array([0, 0, 0]))
+
+
+class TestStaticTargets:
+    def test_init(self):
+        st = StaticTargets(1)
+        assert st.priority_distribution is not None
+
+    def test_reset_constant(self):
+        st = StaticTargets(10)
+        st.regenerate_targets = MagicMock()
+        st.reset()
+        assert st.n_targets == 10
+        st.regenerate_targets.assert_called_once()
+
+    @pytest.mark.repeat(10)
+    def test_reset_variable(self):
+        st = StaticTargets((8, 10))
+        st.regenerate_targets = MagicMock()
+        st.reset()
+        assert 8 <= st.n_targets <= 10
+
+    def test_regenerate_targets(self):
+        st = StaticTargets(3, radius=1.0, priority_distribution=lambda: 1)
+        st.n_targets = st._n_targets
+        st.regenerate_targets()
+        assert len(st.targets) == 3
+        for target in st.targets:
+            assert abs(np.linalg.norm(target.location) - 1.0) < 1e-9
+            assert target.priority == 1
+
+    def test_regenerate_targets_repeatable(self):
+        np.random.seed(0)
+        st1 = StaticTargets(3, radius=1.0)
+        st1.reset()
+        np.random.seed(0)
+        st2 = StaticTargets(3, radius=1.0)
+        st2.reset()
+        for t1, t2 in zip(st1.targets, st2.targets):
+            assert (t1.location == t2.location).all()
+
+
+class TestCityTargets:
+    @pytest.mark.parametrize(
+        "lat,long,radius,expected",
+        [
+            (0, 0, 1, np.array([1, 0, 0])),
+            (0, 0, 2, np.array([2, 0, 0])),
+            (90, 0, 1, np.array([0, 0, 1])),
+            (0, 180, 1, np.array([-1, 0, 0])),
+        ],
+    )
+    def test_lla2ecef(self, lat, long, radius, expected):
+        assert abs(lla2ecef(lat, long, radius) - expected < 1e-9).all()
+
+    def mock_data(self, mock_read_csv, n_database=5):
+        mock_read_csv.return_value = MagicMock(
+            iloc=MagicMock(
+                __getitem__=lambda self, i: {
+                    "city": f"city{i}",
+                    "lat": 0.0,
+                    "lng": 0.0,
+                }
+            ),
+            __len__=lambda self: n_database,
+        )
+
+    @pytest.mark.parametrize(
+        "n_targets",
+        [0, 2, 5, 10],
+    )
+    @patch("pandas.read_csv")
+    def test_regenerate_targets(self, mock_read_csv, n_targets):
+        n_database = 5
+        self.mock_data(mock_read_csv, n_database=n_database)
+        ct = CityTargets(n_targets)
+        if n_targets > n_database:
+            with pytest.raises(ValueError):
+                ct.reset()
+        else:
+            ct.reset()
+            assert len(ct.targets) == n_targets
+            possible_names = [f"city{i}" for i in range(5)]
+            for target in ct.targets:
+                assert target.name in possible_names
+
+    @pytest.mark.parametrize(
+        "n_targets,n_select_from",
+        [(0, 2), (1, 2), (2, 2), (3, "all")],
+    )
+    @patch("pandas.read_csv")
+    def test_regenerate_targets_n_select_from(
+        self, mock_read_csv, n_targets, n_select_from
+    ):
+        self.mock_data(mock_read_csv)
+        ct = CityTargets(n_targets, n_select_from=n_select_from)
+        ct.reset()
+        assert len(ct.targets) == n_targets
+        if isinstance(n_select_from, int):
+            possible_names = [f"city{i}" for i in range(n_select_from)]
+            for target in ct.targets:
+                assert target.name in possible_names
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.environment_features.lla2ecef"
+    )
+    @patch("pandas.read_csv")
+    def test_regenerate_targets_offset(self, mock_read_csv, mock_lla2ecef):
+        nominal = np.array([1.0, 0.0, 0.0])
+        mock_lla2ecef.return_value = nominal
+        self.mock_data(mock_read_csv, n_database=10)
+        n_targets = 10
+        ct = CityTargets(n_targets, location_offset=0.01, radius=1.0)
+        ct.reset()
+        for target in ct.targets:
+            assert np.linalg.norm(target.location - nominal) <= 0.03
+            assert abs(np.linalg.norm(target.location) - 1.0) < 1e-9

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_actions.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_actions.py
@@ -1,0 +1,178 @@
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from gymnasium import spaces
+
+from bsk_rl.envs.general_satellite_tasking.scenario import sat_actions as sa
+from bsk_rl.envs.general_satellite_tasking.scenario.environment_features import Target
+
+
+@patch.multiple(sa.DiscreteSatAction, __abstractmethods__=set())
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+class TestDiscreteSatAction:
+    def test_init(self, sat_init):
+        sa.DiscreteSatAction()
+        sat_init.assert_called_once()
+
+    mock_action = MagicMock(__name__="some_action")
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_map,expected_list",
+        [
+            (dict(act_fn=mock_action), {"0": "some_action"}, [mock_action]),
+            (
+                dict(act_fn=mock_action, act_name="new_name"),
+                {"0": "new_name"},
+                [mock_action],
+            ),
+        ],
+    )
+    def test_add_single_action(self, sat_init, kwargs, expected_map, expected_list):
+        sat = sa.DiscreteSatAction()
+        sat.add_action(**kwargs)
+        assert sat.action_map == expected_map
+        assert sat.action_list == expected_list
+
+    @pytest.mark.parametrize("n_actions", [1, 3])
+    def test_add_multiple_actions(self, sat_init, n_actions):
+        sat = sa.DiscreteSatAction()
+        sat.some_action = MagicMock(
+            __name__="some_action", side_effect=lambda x, prev_action_key=None: x
+        )
+        sat.add_action(sat.some_action, n_actions=n_actions)
+        assert sat.action_map == {f"0-{n_actions-1}": "some_action"}
+        assert [act() for act in sat.action_list] == list(range(n_actions))
+        sat.some_action.assert_has_calls(
+            [call(i, prev_action_key=None) for i in range(n_actions)]
+        )
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite._disable_timed_terminal_event"
+    )
+    def test_set_action(self, sat_init, disable_timed):
+        sat = sa.DiscreteSatAction()
+        sat.action_list = [MagicMock(return_value="act_key")]
+        sat.set_action(0)
+        disable_timed.assert_called_once()
+        sat.action_list[0].assert_called_once()
+        assert sat.prev_action_key == "act_key"
+
+    def test_action_space(self, sat_init):
+        sat = sa.DiscreteSatAction()
+        sat.action_list = [0, 1, 2]
+        assert sat.action_space == spaces.Discrete(3)
+
+
+@patch.multiple(sa.DiscreteSatAction, __abstractmethods__=set())
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+class TestFSWAction:
+    def test_init(self, sat_init):
+        FSWAct = sa.fsw_action_gen("cool_action")
+        sat = FSWAct(action_duration=10.0)
+        sat_init.assert_called_once()
+        assert sat.cool_action_duration == 10.0
+
+    def make_action_sat(self):
+        FSWAct = sa.fsw_action_gen("cool_action")
+        sat = FSWAct()
+        sat.fsw = MagicMock(cool_action=MagicMock())
+        sat.log_info = MagicMock()
+        sat._disable_timed_terminal_event = MagicMock()
+        sat._update_timed_terminal_event = MagicMock()
+        sat.simulator = MagicMock(sim_time=0.0)
+        return sat
+
+    def test_act(self, sat_init):
+        sat = self.make_action_sat()
+        assert sat.action_list[0].__name__ == "act_cool_action"
+        sat.set_action(0)
+        assert "cool_action" == sat.prev_action_key
+        sat.log_info.assert_called_once_with("cool_action tasked for 60.0 seconds")
+        sat.fsw.cool_action.assert_called_once()
+
+    def test_retask(self, sat_init):
+        sat = self.make_action_sat()
+        sat.set_action(0)
+        sat.set_action(0)
+        sat.fsw.cool_action.assert_called_once()
+
+
+@patch.multiple(sa.ImagingActions, __abstractmethods__=set())
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.ImagingSatellite.__init__"
+)
+class TestImagingActions:
+    def test_init(self, sat_init):
+        sat = sa.ImagingActions(n_ahead_act=3)
+        sat_init.assert_called_once()
+        assert sat.action_map == {"0-2": "image"}
+
+    class MockTarget(MagicMock, Target):
+        @property
+        def id(self):
+            return "target_1"
+
+    @pytest.mark.parametrize("target", [1, "target_1", MockTarget()])
+    def test_image(self, sat_init, target):
+        sat = sa.ImagingActions()
+        sat.log_info = MagicMock()
+        sat.parse_target_selection = MagicMock(return_value=self.MockTarget())
+        sat.task_target_for_imaging = MagicMock()
+        assert "target_1" == sat.image(target)
+        sat.task_target_for_imaging.assert_called_once_with(
+            sat.parse_target_selection()
+        )
+
+    @pytest.mark.parametrize("target", [1, "target_1", MockTarget()])
+    def test_image_retask(self, sat_init, target):
+        sat = sa.ImagingActions()
+        sat.log_info = MagicMock()
+        sat.parse_target_selection = MagicMock(return_value=self.MockTarget())
+        sat.task_target_for_imaging = MagicMock()
+        sat.image(target, prev_action_key="target_1")
+        sat.task_target_for_imaging.assert_not_called()
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.sat_actions.DiscreteSatAction.set_action"
+    )
+    @pytest.mark.parametrize("target", [1, "target_1", MockTarget()])
+    def test_set_action(self, sat_init, discrete_set, target):
+        sat = sa.ImagingActions()
+        sat._disable_image_event = MagicMock()
+        sat.image = MagicMock()
+        sat.set_action(target)
+        sat._disable_image_event.assert_called()
+        if isinstance(target, int):
+            discrete_set.assert_called_once()
+        elif isinstance(target, (Target, str)):
+            sat.image.assert_called_once()
+
+
+@patch.multiple(sa.ChargingAction, __abstractmethods__=set())
+@patch.multiple(sa.DriftAction, __abstractmethods__=set())
+@patch.multiple(sa.DesatAction, __abstractmethods__=set())
+@patch.multiple(sa.DownlinkAction, __abstractmethods__=set())
+@patch.multiple(sa.ImagingActions, __abstractmethods__=set())
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.ImagingSatellite.__init__"
+)
+def test_combination(sat_init):
+    class ComboAct(
+        sa.ImagingActions.configure(n_ahead_act=3),
+        sa.DownlinkAction,
+        sa.DesatAction,
+        sa.DriftAction,
+        sa.ChargingAction,
+    ):
+        pass
+
+    sat = ComboAct()
+    assert sat.action_map == {
+        "0": "action_charge",
+        "1": "action_drift",
+        "2": "action_desat",
+        "3": "action_downlink",
+        "4-6": "image",
+    }
+    assert len(sat.action_list) == 7
+    sat_init.assert_called_once()

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
@@ -1,0 +1,193 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.scenario import sat_observations as so
+
+
+@patch.multiple(so.SatObservation, __abstractmethods__=set())
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+class TestSatObservation:
+    def test_init(self, sat_init):
+        so.SatObservation()
+        sat_init.assert_called_once()
+
+    def make_mocked_observation(self, **kwargs):
+        sat = so.SatObservation(**kwargs)
+        sat.simulator = MagicMock(sim_time=0.0)
+        obs_fun = MagicMock(return_value=0, __name__="obs")
+        sat.add_to_observation(obs_fun)
+        return sat
+
+    def test_obs_dict(self, sat_init):
+        sat = self.make_mocked_observation()
+        assert sat.obs_dict == {"obs": 0}
+
+    def test_obs_dict_cache(self, sat_init):
+        sat = self.make_mocked_observation()
+        sat.obs_dict
+        # Don't step time forward, expect cached value
+        sat.obs_fn_list[0].return_value = 1
+        assert sat.obs_dict == {"obs": 0}
+        # Don't step time forward, expect new value
+        sat.simulator.sim_time = 1.0
+        assert sat.obs_dict == {"obs": 1}
+
+    @pytest.mark.parametrize(
+        "obs_type,observation",
+        [(dict, {"obs": 0}), (np.ndarray, np.array([0])), (list, [0]), (int, None)],
+    )
+    def test_get_obs(self, sat_init, obs_type, observation):
+        sat = self.make_mocked_observation(obs_type=obs_type)
+        if observation is None:
+            with pytest.raises(ValueError):
+                sat.get_obs()
+        else:
+            assert sat.get_obs() == observation
+
+
+@patch.multiple(so.NormdPropertyState, __abstractmethods__=set())
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+class TestNormdPropertyState:
+    def test_init(self, sat_init):
+        sat = so.NormdPropertyState(obs_properties=[dict(prop="some_prop")])
+        sat_init.assert_called_once()
+        assert len(sat.obs_fn_list) == 1
+        assert sat.obs_fn_list[0].__name__ == "some_prop"
+
+    def make_mocked_sat(self, **kwargs):
+        sat = so.NormdPropertyState(**kwargs)
+        sat.simulator = MagicMock(sim_time=0.0)
+        sat.dynamics = MagicMock([], some_prop=0.0)
+        sat.fsw = MagicMock([], other_prop=1.0)
+        return sat
+
+    def test_add_prop_function_with_module(self, sat_init):
+        sat = self.make_mocked_sat()
+        sat.add_prop_function("some_prop", module="dynamics")
+        sat.add_prop_function("other_prop", module="fsw")
+        assert sat.obs_dict == {"some_prop": 0.0, "other_prop": 1.0}
+
+    def test_add_prop_function_no_module(self, sat_init):
+        sat = self.make_mocked_sat()
+        sat.add_prop_function("some_prop")
+        sat.add_prop_function("other_prop")
+        assert sat.obs_dict == {"some_prop": 0.0, "other_prop": 1.0}
+
+    def test_add_prop_function_norm(self, sat_init):
+        sat = self.make_mocked_sat()
+        sat.add_prop_function("other_prop", norm=10.0)
+        assert sat.obs_dict == {"other_prop_normd": 0.1}
+
+
+@patch.multiple(so.TimeState, __abstractmethods__=set())
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+class TestTimeState:
+    def test_init(self, sat_init):
+        sat = so.TimeState()
+        sat_init.assert_called_once()
+        assert len(sat.obs_fn_list) == 1
+        assert sat.obs_fn_list[0].__name__ == "normalized_time"
+
+    def test_explicit_normalization(self, sat_init):
+        sat = so.TimeState(normalization_time=10.0)
+        sat.simulator = MagicMock(sim_time=1.0)
+        sat.reset_post_sim()
+        assert sat.normalized_time() == 0.1
+
+    def test_implicit_normalization(self, sat_init):
+        sat = so.TimeState(normalization_time=None)
+        sat.simulator = MagicMock(sim_time=1.0, time_limit=10.0)
+        sat.reset_post_sim()
+        assert sat.normalized_time() == 0.1
+
+
+@patch.multiple(so.TargetState, __abstractmethods__=set())
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.ImagingSatellite.__init__"
+)
+class TestTargetState:
+    def test_init(self, sat_init):
+        sat = so.TargetState()
+        sat_init.assert_called_once()
+        assert len(sat.obs_fn_list) == 1
+        assert sat.obs_fn_list[0].__name__ == "target_obs"
+
+    def test_target_state(self, sat_init):
+        n_ahead = 2
+        sat = so.TargetState(n_ahead_observe=n_ahead, location_norm=1.0)
+        sat.upcoming_targets = MagicMock(
+            return_value=[
+                MagicMock(priority=i, location=np.array([i, 1.0, 0.0]))
+                for i in range(n_ahead)
+            ]
+        )
+        expected = {
+            "tgt_value_0": 0,
+            "tgt_loc_0": np.array([0.0, 1.0, 0.0]),
+            "tgt_value_1": 1,
+            "tgt_loc_1": np.array([1.0, 1.0, 0.0]),
+        }
+        for k, v in sat.target_obs().items():
+            assert np.all(v == expected[k])
+
+    def test_target_state_normed(self, sat_init):
+        n_ahead = 2
+        sat = so.TargetState(n_ahead_observe=n_ahead, location_norm=10.0)
+        sat.upcoming_targets = MagicMock(
+            return_value=[
+                MagicMock(priority=i, location=np.array([i, 1.0, 0.0]))
+                for i in range(n_ahead)
+            ]
+        )
+        expected = {
+            "tgt_value_0": 0,
+            "tgt_loc_0_normd": np.array([0.0, 0.1, 0.0]),
+            "tgt_value_1": 1,
+            "tgt_loc_1_normd": np.array([0.1, 0.1, 0.0]),
+        }
+        for k, v in sat.target_obs().items():
+            assert np.all(v == expected[k])
+
+
+@patch.multiple(so.EclipseState, __abstractmethods__=set())
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+class TestEclipseState:
+    def test_init(self, sat_init):
+        sat = so.EclipseState()
+        sat_init.assert_called_once()
+        assert len(sat.obs_fn_list) == 1
+        assert sat.obs_fn_list[0].__name__ == "eclipse_state"
+
+    def test_eclipse_state(self, sat_init):
+        sat = so.EclipseState(orbit_period=10.0)
+        sat.trajectory = MagicMock(next_eclipse=MagicMock(return_value=(2.0, 3.0)))
+        sat.simulator = MagicMock(sim_time=1.0)
+        assert sat.eclipse_state() == [0.1, 0.2]
+
+
+@patch.multiple(so.NormdPropertyState, __abstractmethods__=set())
+@patch.multiple(so.TimeState, __abstractmethods__=set())
+@patch.multiple(so.TargetState, __abstractmethods__=set())
+@patch.multiple(so.EclipseState, __abstractmethods__=set())
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.ImagingSatellite.__init__"
+)
+def test_combination(sat_init):
+    class ComboObs(
+        so.EclipseState,
+        so.TargetState,
+        so.TimeState,
+        so.NormdPropertyState.configure(obs_properties=[dict(prop="some_prop")]),
+    ):
+        pass
+
+    sat = ComboObs()
+    sat_init.assert_called_once()
+    assert [fn.__name__ for fn in sat.obs_fn_list] == [
+        "some_prop",
+        "normalized_time",
+        "target_obs",
+        "eclipse_state",
+    ]

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
@@ -148,22 +148,20 @@ class TestSatellite:
 
 
 @patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
 def test_init(mock_init):
     sat = sats.ImagingSatellite(
         "TestSat",
         sat_args={"imageTargetMinimumElevation": 1},
-        n_ahead_observe=20.0,
-        n_ahead_act=10.0,
     )
     mock_init.assert_called_once()
-    assert isinstance(sat.n_ahead_act, int)
-    assert isinstance(sat.n_ahead_observe, int)
 
 
 @patch(
     "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__",
     MagicMock(),
 )
+@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
 class TestImagingSatellite:
     def make_sat(self):
         return sats.ImagingSatellite(
@@ -346,6 +344,7 @@ class TestImagingSatellite:
 @patch(
     "bsk_rl.envs.general_satellite_tasking.utils.orbital.elevation", lambda x, y: y - x
 )
+@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
 class TestCalculateWindows:
     def make_sat(self):
         return sats.ImagingSatellite(

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
@@ -1,0 +1,530 @@
+from collections.abc import Iterable
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box
+
+from bsk_rl.envs.general_satellite_tasking.scenario import satellites as sats
+from bsk_rl.envs.general_satellite_tasking.scenario.environment_features import Target
+from bsk_rl.envs.general_satellite_tasking.simulation.fsw import Task
+
+
+@patch.multiple(sats.Satellite, __abstractmethods__=set())
+class TestSatellite:
+    sats.Satellite.dyn_type = MagicMock(with_defaults=MagicMock(defaults={"a": 1}))
+    Task.with_defaults = MagicMock(defaults={"c": 3})
+    sats.Satellite.fsw_type = MagicMock(
+        with_defaults=MagicMock(defaults={"b": 2}),
+        some_task=Task,
+    )
+
+    def test_default_sat_args(self):
+        assert sats.Satellite.default_sat_args() == {"a": 1, "b": 2, "c": 3}
+
+    @pytest.mark.parametrize(
+        "overwrite,error", [({"c": 4}, False), ({"not_c": 4}, True)]
+    )
+    def test_default_sat_args_overwrote(self, overwrite, error):
+        if not error:
+            assert sats.Satellite.default_sat_args(**overwrite) == {
+                "a": 1,
+                "b": 2,
+                "c": 4,
+            }
+        else:
+            with pytest.raises(AssertionError):
+                sats.Satellite.default_sat_args(**overwrite)
+
+    def test_init_default(self):
+        sat = sats.Satellite(name="TestSat", sat_args=None)
+        assert sat.sat_args_generator == {"a": 1, "b": 2, "c": 3}
+
+    def test_id(self):
+        sat1 = sats.Satellite(name="TestSat", sat_args={})
+        sat2 = sats.Satellite(name="TestSat", sat_args={})
+        assert sat1.id != sat2.id
+        assert sat1.id.startswith("TestSat")
+
+    def test_generate_sat_args(self):
+        sat = sats.Satellite(name="TestSat", sat_args={"a": 4, "b": lambda: 5})
+        sat._generate_sat_args()
+        assert sat.sat_args == {"a": 4, "b": 5, "c": 3}
+
+    # @patch("bsk_rl.envs.general_satellite_tasking.utils.orbital.TrajectorySimulator")
+    # def test_reset_pre_sim(self, trajsim_patch):
+    #     sat = sats.Satellite(name="TestSat", sat_args=None)
+    #     sat.data_store = MagicMock(is_fresh=True)
+    #     sat._generate_sat_args = MagicMock()
+    #     sat.sat_args = {"utc_init": 0, "rN": 0, "vN": 0, "oe": 0, "mu": 0}
+    #     sat.reset_pre_sim()
+    #     trajsim_patch.assert_called_once()
+    #     sat._generate_sat_args.assert_called_once()
+    #     assert sat.info == []
+    #     assert sat._timed_terminal_event_name is None
+
+    @pytest.mark.parametrize(
+        "obs,space",
+        [
+            (np.array([1]), Box(low=-1e16, high=1e16, shape=(1,), dtype=np.float64)),
+            (np.array([1, 2]), Box(low=-1e16, high=1e16, shape=(2,), dtype=np.float64)),
+        ],
+    )
+    def test_obs_space(self, obs, space):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat.get_obs = MagicMock(return_value=obs)
+        assert sat.observation_space == space
+
+    @pytest.mark.parametrize(
+        "dyn_state,fsw_state",
+        [(False, False), (False, True), (True, False), (True, True)],
+    )
+    def test_is_alive(self, dyn_state, fsw_state):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat.dynamics = MagicMock(is_alive=MagicMock(return_value=dyn_state))
+        sat.fsw = MagicMock(is_alive=MagicMock(return_value=fsw_state))
+        assert sat.is_alive() == (dyn_state and fsw_state)
+
+    def test_satellite_command(self):
+        sat1 = sats.Satellite(name="TestSat", sat_args={})
+        sat2 = sats.Satellite(name="TestSat", sat_args={})
+        self.satellites = [sat1, sat2]
+        assert sat1 == eval(sat1._satellite_command)
+        assert sat1 != eval(sat2._satellite_command)
+        assert sat2 == eval(sat2._satellite_command)
+
+    def test_info_command(self):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat.info = []
+        self.satellites = [sat]
+        self.sim_time = 0.0
+        eval(sat._info_command("some info"))
+        assert sat.info[0] == (0.0, "some info")
+
+    def test_log_info(self):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat.info = []
+        sat.simulator = MagicMock(sim_time=0.0)
+        sat.log_info("some info")
+        assert sat.info[0] == (0.0, "some info")
+
+    def test_update_timed_terminal_event(self):
+        pass  # Probably better with integration testing
+
+    def test_disable_timed_event(self):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat.simulator = MagicMock()
+        sat._timed_terminal_event_name = "some_event"
+        sat._disable_timed_terminal_event()
+        assert sat.simulator.eventMap.__getitem__.called
+
+    def test_disable_timed_event_no_event(self):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat.simulator = MagicMock()
+        sat._timed_terminal_event_name = None
+        sat._disable_timed_terminal_event()
+        assert not sat.simulator.eventMap.__getitem__.called
+
+    def test_proxy_setters(self):
+        # Must be last test or others break
+        mock_sim = MagicMock()
+        mock_dyn = MagicMock()
+        mock_fsw = MagicMock()
+
+        sat = sats.Satellite(name="TestSat", sat_args=None)
+        sat.dyn_type.return_value = mock_dyn
+        sat.fsw_type.return_value = mock_fsw
+        sat._generate_sat_args()
+        sat.set_simulator(mock_sim)
+        assert mock_dyn == sat.set_dynamics(1.0)
+        assert mock_fsw == sat.set_fsw(1.0)
+        # Should be proxies, not the actual object
+        assert sat.simulator is not mock_sim
+        assert sat.simulator == mock_sim
+        assert sat.fsw is not mock_fsw
+        assert sat.fsw == mock_fsw
+        assert sat.dynamics is not mock_dyn
+        assert sat.dynamics == mock_dyn
+
+
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+def test_init(mock_init):
+    sat = sats.ImagingSatellite(
+        "TestSat",
+        sat_args={"imageTargetMinimumElevation": 1},
+        n_ahead_observe=20.0,
+        n_ahead_act=10.0,
+    )
+    mock_init.assert_called_once()
+    assert isinstance(sat.n_ahead_act, int)
+    assert isinstance(sat.n_ahead_observe, int)
+
+
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__",
+    MagicMock(),
+)
+class TestImagingSatellite:
+    def make_sat(self):
+        return sats.ImagingSatellite(
+            "TestSat",
+            sat_args={"imageTargetMinimumElevation": 1},
+        )
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.reset_pre_sim"
+    )
+    def test_reset_pre_sim(self, mock_reset):
+        sat = self.make_sat()
+        sat.data_store = MagicMock()
+        sat.data_store.env_knowledge.targets = [MagicMock()] * 5
+        sat.sat_args = {}
+        sat.reset_pre_sim()
+        mock_reset.assert_called_once()
+        assert sat.sat_args["transmitterNumBuffers"] == 5
+        assert len(sat.sat_args["bufferNames"]) == 5
+
+    @pytest.mark.parametrize(
+        "gen_duration,time_limit,expected",
+        [(None, float("inf"), 0), (None, 100.0, 100.0), (10.0, 100.0, 10.0)],
+    )
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.reset_post_sim"
+    )
+    def test_reset_post_sim(self, mock_reset, gen_duration, time_limit, expected):
+        sat = self.make_sat()
+        sat.sat_args = {}
+        sat.calculate_additional_windows = MagicMock()
+        sat.initial_generation_duration = gen_duration
+        sat.simulator = MagicMock(time_limit=time_limit)
+        sat.reset_post_sim()
+        mock_reset.assert_called_once()
+        assert sat.initial_generation_duration == expected
+        sat.calculate_additional_windows.assert_called_once()
+
+    tgt0 = Target("tgt_0", location=[0.0, 0.0, 0.0], priority=1.0)
+    tgt1 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
+    tgt2 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
+    windows = {
+        tgt0: [(0.0, 10.0), (20.0, 30.0), (40.0, 50.0)],
+        tgt1: [(10.0, 20.0)],
+        tgt2: [(30.0, 40.0)],
+    }
+
+    def test_upcoming_windows_unfiltered(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=25.0)
+        sat.windows = self.windows
+        assert sat.upcoming_windows == {
+            self.tgt0: [(20.0, 30.0), (40.0, 50.0)],
+            self.tgt2: [(30.0, 40.0)],
+        }
+
+    def test_upcoming_windows_filtered(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=25.0)
+        sat.windows = self.windows
+        sat.data_store = MagicMock(data=MagicMock(imaged=[self.tgt0]))
+        assert sat.upcoming_windows == {
+            self.tgt2: [(30.0, 40.0)],
+        }
+
+    def test_next_windows(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.windows = self.windows
+        assert sat.next_windows == {
+            self.tgt0: (40.0, 50.0),
+            self.tgt2: (30.0, 40.0),
+        }
+
+    def test_upcoming_targets(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.windows = self.windows
+        assert sat.upcoming_targets(2) == [self.tgt2, self.tgt0]
+
+    def test_no_upcoming_targets(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.windows = self.windows
+        assert sat.upcoming_targets(0) == []
+
+    def test_upcoming_targets_pad(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.windows = self.windows
+        sat.calculate_additional_windows = MagicMock()
+        assert sat.upcoming_targets(4, pad=True) == [
+            self.tgt2,
+            self.tgt0,
+            self.tgt0,
+            self.tgt0,
+        ]
+
+    def test_upcoming_targets_generate_more(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.windows = self.windows
+        sat.calculate_additional_windows = MagicMock(
+            side_effect=lambda t: self.windows[self.tgt1].append((60.0, 70.0))
+        )
+        assert sat.upcoming_targets(3, pad=True) == [
+            self.tgt2,
+            self.tgt0,
+            self.tgt1,
+        ]
+
+    def test_update_image_event(self):
+        pass  # Probably better with integration testing
+
+    def test_disable_image_event(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock()
+        sat._image_event_name = "some_image_event"
+        sat._disable_image_event()
+        assert sat.simulator.eventMap.__getitem__.called
+
+    def test_disable_image_event_no_event(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock()
+        sat._image_event_name = None
+        sat._disable_image_event()
+        assert not sat.simulator.eventMap.__getitem__.called
+
+    upcoming_targets = [Target(f"tgt_{i}", [0, 0, 0], 1.0) for i in range(20)]
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            (0, "tgt_0"),
+            (3, "tgt_3"),
+            (upcoming_targets[2].id, "tgt_2"),
+            (upcoming_targets[2], "tgt_2"),
+        ],
+    )
+    def test_parse_target_selection(self, query, expected):
+        sat = self.make_sat()
+        sat.upcoming_targets = lambda x: self.upcoming_targets[0:x]
+        sat.data_store = MagicMock(
+            env_knowledge=MagicMock(targets=self.upcoming_targets)
+        )
+        assert expected == sat.parse_target_selection(query).name
+
+    def test_parse_target_selection_invalid(self):
+        sat = self.make_sat()
+        sat.upcoming_targets = lambda x: self.upcoming_targets[0:x]
+        sat.data_store = MagicMock(
+            env_knowledge=MagicMock(targets=self.upcoming_targets)
+        )
+        with pytest.raises(TypeError):
+            sat.parse_target_selection(np.zeros(10))
+
+    def test_task_target_for_imaging(self):
+        sat = self.make_sat()
+        sat.windows = self.windows
+        sat.name = "Sat"
+        sat.fsw = MagicMock()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat._update_image_event = MagicMock()
+        sat._update_timed_terminal_event = MagicMock()
+        sat.log_info = MagicMock()
+        sat.task_target_for_imaging(self.tgt0)
+        sat.fsw.action_image.assert_called_once()
+        assert sat.fsw.action_image.call_args[0][1].startswith("tgt_0")
+        sat.log_info.assert_called_once()
+        sat._update_image_event.assert_called_once()
+        assert sat._update_image_event.call_args[0][0] == self.tgt0
+        sat._update_timed_terminal_event.assert_called_once()
+        assert sat._update_timed_terminal_event.call_args[0][0] == 50.0
+
+
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__",
+    MagicMock(),
+)
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.utils.orbital.elevation", lambda x, y: y - x
+)
+class TestCalculateWindows:
+    def make_sat(self):
+        return sats.ImagingSatellite(
+            "TestSat",
+            sat_args={"imageTargetMinimumElevation": 1},
+        )
+
+    @pytest.mark.parametrize("start", [0.0, 100.0])
+    @pytest.mark.parametrize("duration", [0.0, 20.0, 500.0])
+    @pytest.mark.parametrize("traj_dt", [30.0, 200.0])
+    @pytest.mark.parametrize("generation_duration", [60.0, 100.0])
+    def test_calculate_windows_duration(
+        self, start, duration, traj_dt, generation_duration
+    ):
+        sat = self.make_sat()
+        sat.window_calculation_time = start
+        sat.generation_duration = generation_duration
+        sat.trajectory = MagicMock(
+            dt=traj_dt,
+            r_BP_P=MagicMock(
+                x=np.linspace(0, start + duration), y=np.linspace(0, start + duration)
+            ),
+        )
+        sat.data_store = MagicMock()
+        sat.data_store.env_knowledge.targets = []
+        sat.calculate_additional_windows(duration)
+        if duration == 0.0:
+            return
+        assert sat.trajectory.extend_to.call_args[0][0] >= start + duration
+        assert sat.trajectory.extend_to.call_args[0][0] - start >= traj_dt * 2
+
+    def test_calculate_windows(self):
+        tgt = Target("tgt_0", location=[0.0, 0.0, 1.0], priority=1.0)
+        sat = self.make_sat()
+        sat.window_calculation_time = 0.0
+        sat.windows = {}
+        sat.min_elev = 1.3
+        sat.target_dist_threshold = 5.0
+        sat.trajectory = MagicMock(
+            dt=2.0,
+            r_BP_P=MagicMock(
+                x=np.arange(0, 100, 2),
+                y=np.array([[t - 50.0, 0.0, 2.0] for t in np.arange(0, 100, 2)]),
+                side_effect=(  # noqa: E731
+                    lambda t: np.array([[ti - 50.0, 0.0, 2.0] for ti in t])
+                    if isinstance(t, Iterable)
+                    else np.array([t - 50.0, 0.0, 2.0])
+                ),
+            ),
+        )
+        sat.data_store = MagicMock()
+        sat.data_store.env_knowledge.targets = [tgt]
+        sat.calculate_additional_windows(100.0)
+        assert tgt in sat.windows
+        assert abs(sat.windows[tgt][0][0] - (50 - 0.27762037530835193)) < 1e-2
+        assert abs(sat.windows[tgt][0][1] - (50 + 0.27762037530835193)) < 1e-2
+
+    def test_find_elevation_roots(self):
+        interp = (  # noqa: E731
+            lambda t: np.array([[ti, 0.0, 2.0] for ti in t])
+            if isinstance(t, Iterable)
+            else np.array([t, 0.0, 2.0])
+        )
+        loc = np.array([0.0, 0.0, 1.0])
+        elev = 1.3
+        times = sats.ImagingSatellite._find_elevation_roots(interp, loc, elev, (-1, 1))
+        assert len(times) == 2
+        assert abs(times[0] - -times[1]) < 1e-5
+        assert abs(times[1] - 0.27762037530835193) < 1e-5
+        times = sats.ImagingSatellite._find_elevation_roots(interp, loc, elev, (0, 1))
+        assert len(times) == 1
+        assert abs(times[0] - 0.27762037530835193) < 1e-5
+
+    @pytest.mark.parametrize(
+        "location,times,positions,threshold,expected",
+        [
+            (
+                np.array([2.5, 0.0]),
+                np.array([0.0, 10.0, 20.0, 30.0]),
+                np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+                1.0,
+                [(10.0, 30.0)],
+            ),
+            (
+                np.array([2.5, 0.0]),
+                np.array([0.0, 10.0, 20.0, 30.0, 40.0]),
+                np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [4.0, 0.0]]),
+                1.0,
+                [(10.0, 40.0)],
+            ),
+            (
+                np.array([0.5, 0.0]),
+                np.array([0.0, 10.0, 20.0, 30.0]),
+                np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+                1.0,
+                [(0.0, 20.0)],
+            ),
+            (
+                np.array([1.2, 0.0]),
+                np.array([0.0, 10.0, 20.0, 30.0]),
+                np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+                5.0,
+                [(0.0, 30.0)],
+            ),
+            (
+                np.array([2.5, 100.0]),
+                np.array([0.0, 10.0, 20.0, 30.0]),
+                np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+                1.0,
+                [],
+            ),
+            (
+                np.array([-0.1, 0.0]),
+                np.array([0.0, 10.0, 20.0, 30.0, 40.0]),
+                np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [-1.0, 0.0]]),
+                1.0,
+                [(0.0, 10.0), (30.0, 40.0)],
+            ),
+        ],
+    )
+    def test_find_candidate_windows(
+        self, location, times, positions, threshold, expected
+    ):
+        assert (
+            sats.ImagingSatellite._find_candidate_windows(
+                location, times, positions, threshold
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "endpoints,candidate_window,computation_window,expected",
+        [
+            ([2.4, 14.6], (0.0, 20.0), (0.0, 30.0), [(2.4, 14.6)]),
+            ([12.4], (0.0, 20.0), (0.0, 30.0), [(0.0, 12.4)]),
+            ([12.4], (10.0, 30.0), (0.0, 30.0), [(12.4, 30.0)]),
+            ([2.4, 14.6, 18.8], (0.0, 20.0), (0.0, 30.0), [(0.0, 2.4), (14.6, 18.8)]),
+            (
+                [2.4, 14.6, 18.8, 19.3],
+                (0.0, 20.0),
+                (0.0, 30.0),
+                [(2.4, 14.6), (18.8, 19.3)],
+            ),
+        ],
+    )
+    def test_refine_windows(
+        self, endpoints, candidate_window, computation_window, expected
+    ):
+        assert (
+            sats.ImagingSatellite._refine_window(
+                endpoints, candidate_window, computation_window
+            )
+            == expected
+        )
+
+    def test_refine_windows_impossible(self):
+        with pytest.raises(ValueError):
+            sats.ImagingSatellite._refine_window(
+                [1.0, 2.0, 3.0], (0.0, 4.0), (0.5, 3.5)
+            )
+
+    tgt0 = Target("tgt_0", location=[0.0, 0.0, 0.0], priority=1.0)
+    tgt1 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
+    tgt2 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
+
+    @pytest.mark.parametrize(
+        "merge_time",
+        [None, 10.0],
+    )
+    @pytest.mark.parametrize(
+        "tgt,window,expected_window",
+        [
+            (tgt0, (13.0, 18.0), (13.0, 18.0)),
+            (tgt2, (13.0, 18.0), (13.0, 18.0)),
+            (tgt0, (10.0, 18.0), (2.0, 18.0)),  # Check that merging works
+        ],
+    )
+    def test_add_window(self, merge_time, tgt, window, expected_window):
+        sat = self.make_sat()
+        sat.windows = {self.tgt0: [(2.0, 10.0)], self.tgt1: [(3.0, 8.0)]}
+        sat._add_window(tgt, window, merge_time=merge_time)
+        assert expected_window in sat.windows[tgt]

--- a/tests/unittest/envs/general_satellite_tasking/simulation/test_dynamics.py
+++ b/tests/unittest/envs/general_satellite_tasking/simulation/test_dynamics.py
@@ -1,0 +1,258 @@
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pytest
+from Basilisk.utilities import macros as mc
+
+from bsk_rl.envs.general_satellite_tasking.simulation import environment
+from bsk_rl.envs.general_satellite_tasking.simulation.dynamics import (
+    BasicDynamicsModel,
+    DynamicsModel,
+    GroundStationDynModel,
+    ImagingDynModel,
+    LOSCommDynModel,
+)
+
+module = "bsk_rl.envs.general_satellite_tasking.simulation.dynamics."
+
+
+@patch.multiple(DynamicsModel, __abstractmethods__=set())
+class TestDynamicsModel:
+    def test_base_class(self):
+        sat = MagicMock()
+        dyn = DynamicsModel(sat, 1.0)
+        dyn.simulator.CreateNewProcess.assert_called_once()
+        assert sat.simulator.environment == dyn.environment
+        dyn.reset_for_action()
+
+    @patch(module + "check_aliveness_checkers", MagicMock(return_value=True))
+    def test_is_alive(self):
+        dyn = DynamicsModel(MagicMock(), 1.0)
+        assert dyn.is_alive()
+
+
+basicdyn = module + "BasicDynamicsModel."
+
+
+def test_basic_requires_env():
+    assert environment.BasicEnvironmentModel in BasicDynamicsModel.requires_env
+
+
+@patch(basicdyn + "requires_env", MagicMock(return_value=[]))
+@patch(basicdyn + "_set_spacecraft_hub")
+@patch(basicdyn + "_set_drag_effector")
+@patch(basicdyn + "_set_reaction_wheel_dyn_effector")
+@patch(basicdyn + "_set_thruster_dyn_effector")
+@patch(basicdyn + "_set_simple_nav_object")
+@patch(basicdyn + "_set_eclipse_object")
+@patch(basicdyn + "_set_solar_panel")
+@patch(basicdyn + "_set_battery")
+@patch(basicdyn + "_set_reaction_wheel_power")
+def test_basic_init_objects(self, *args):
+    BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+    for setter in args:
+        setter.assert_called_once()
+
+
+@patch(basicdyn + "requires_env", MagicMock(return_value=[]))
+@patch(basicdyn + "_init_dynamics_objects", MagicMock())
+class TestBasicDynamicsModel:
+    def test_dynamic_properties(self):
+        dyn = BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.simulator.environment = MagicMock(PN=np.identity(3), omega_PN_N=np.zeros(3))
+        dyn.scObject = MagicMock()
+        message = dyn.scObject.scStateOutMsg.read.return_value
+        message.sigma_BN = np.zeros(3)
+        message.omega_BN_B = np.zeros(3)
+        message.r_BN_N = np.zeros(3)
+        message.v_BN_N = np.zeros(3)
+        assert (dyn.sigma_BN == np.zeros(3)).all()
+        assert (dyn.BN == np.identity(3)).all()
+        assert (dyn.omega_BN_B == np.zeros(3)).all()
+        assert (dyn.BP == np.identity(3)).all()
+        assert (dyn.r_BN_N == np.zeros(3)).all()
+        assert (dyn.r_BN_P == np.zeros(3)).all()
+        assert (dyn.v_BN_N == np.zeros(3)).all()
+        assert (dyn.v_BN_P == np.zeros(3)).all()
+        assert (dyn.omega_BP_P == np.zeros(3)).all()
+
+    def test_battery_properties(self):
+        dyn = BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.powerMonitor = MagicMock()
+        dyn.powerMonitor.batPowerOutMsg.read.return_value.storageLevel = 50.0
+        dyn.powerMonitor.storageCapacity = 100.0
+        assert dyn.battery_charge == 50.0
+        assert dyn.battery_charge_fraction == 0.5
+
+    def test_wheel_properties(self):
+        dyn = BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.rwStateEffector = MagicMock()
+        speeds = np.array([10.0, 20.0, 30.0]) * mc.rpm2radsec
+        dyn.rwStateEffector.rwSpeedOutMsg.read.return_value.wheelSpeeds = speeds
+        dyn.maxWheelSpeed = 100.0
+        assert (dyn.wheel_speeds == speeds).all()
+        assert (abs(dyn.wheel_speeds_fraction - np.array([0.1, 0.2, 0.3])) < 1e-9).all()
+
+    @pytest.mark.parametrize(
+        "vec,valid",
+        [([1, 1, 1], False), ([1e9, 0, 1e9], True)],
+    )
+    def test_altitude_valid(self, vec, valid):
+        dyn = BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.simulator.environment = MagicMock()
+        dyn.scObject = MagicMock()
+        message = dyn.scObject.scStateOutMsg.read.return_value
+        message.r_BN_N = vec
+        assert dyn.altitude_valid() == valid
+
+    @pytest.mark.parametrize(
+        "speeds,valid",
+        [
+            ([-10, 0.0, 10.0], True),
+            ([200.0, 50.0, -50.0], False),
+            ([-200.0, 50.0, -50.0], False),
+        ],
+    )
+    def test_rw_speeds_valid(self, speeds, valid):
+        dyn = BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.simulator.environment = MagicMock()
+        dyn.rwStateEffector = MagicMock()
+        speeds = np.array(speeds) * mc.rpm2radsec
+        dyn.rwStateEffector.rwSpeedOutMsg.read.return_value.wheelSpeeds = speeds
+        dyn.maxWheelSpeed = 100.0
+        assert dyn.rw_speeds_valid() == valid
+
+    @pytest.mark.parametrize(
+        "level,valid",
+        [(10, True), (0, False), (-10, False)],
+    )
+    def test_battery_valid(self, level, valid):
+        dyn = BasicDynamicsModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.powerMonitor = MagicMock()
+        dyn.powerMonitor.batPowerOutMsg.read.return_value.storageLevel = level
+        dyn.powerMonitor.storageCapacity = 100.0
+        assert dyn.battery_valid() == valid
+
+
+class TestLOSCommDynModel:
+    losdyn = module + "LOSCommDynModel."
+
+    @patch(losdyn + "requires_env", MagicMock(return_value=[]))
+    @patch(module + "BasicDynamicsModel._init_dynamics_objects", MagicMock())
+    @patch(losdyn + "_set_los_comms")
+    def test_init_objects(self, *args):
+        LOSCommDynModel(MagicMock(simulator=MagicMock()), 1.0)
+        for setter in args:
+            setter.assert_called_once()
+
+    @patch(losdyn + "requires_env", MagicMock(return_value=[]))
+    @patch(losdyn + "_init_dynamics_objects", MagicMock())
+    @patch(module + "spacecraftLocation", MagicMock())
+    def test_set_los_comms(self):
+        mock_sim = MagicMock()
+        dyn1 = LOSCommDynModel(MagicMock(simulator=mock_sim), 1.0)
+        dyn1.scObject = MagicMock()
+        dyn1._set_los_comms(priority=1)
+        mock_sim.dynamics_list = {1: dyn1}
+        mock_sim.AddModelToTask.assert_not_called()
+        assert dyn1.los_comms_ids == []
+
+        dyn2 = LOSCommDynModel(MagicMock(simulator=mock_sim), 1.0)
+        dyn2.scObject = MagicMock()
+        dyn2._set_los_comms(priority=1)
+        mock_sim.dynamics_list[2] = dyn2
+        assert dyn1.los_comms_ids == [dyn2.satellite.id]
+        assert dyn2.los_comms_ids == [dyn1.satellite.id]
+        calls = [
+            call(dyn1.task_name, dyn1.losComms, ModelPriority=1),
+            call(dyn2.task_name, dyn2.losComms, ModelPriority=1),
+        ]
+        mock_sim.AddModelToTask.assert_has_calls(calls)
+
+        dyn3 = LOSCommDynModel(MagicMock(simulator=mock_sim), 1.0)
+        dyn3.scObject = MagicMock()
+        dyn3._set_los_comms(priority=1)
+        mock_sim.dynamics_list[3] = dyn3
+        assert dyn1.los_comms_ids == [dyn2.satellite.id, dyn3.satellite.id]
+        assert dyn2.los_comms_ids == [dyn1.satellite.id, dyn3.satellite.id]
+        assert dyn3.los_comms_ids == [dyn1.satellite.id, dyn2.satellite.id]
+        calls += [call(dyn3.task_name, dyn3.losComms, ModelPriority=1)]
+        mock_sim.AddModelToTask.assert_has_calls(calls)
+
+
+imdyn = module + "ImagingDynModel."
+
+
+@patch(imdyn + "requires_env", MagicMock(return_value=[]))
+@patch(module + "BasicDynamicsModel._init_dynamics_objects", MagicMock())
+@patch(imdyn + "_set_instrument_power_sink")
+@patch(imdyn + "_set_transmitter_power_sink")
+@patch(imdyn + "_set_instrument")
+@patch(imdyn + "_set_transmitter")
+@patch(imdyn + "_set_storage_unit")
+@patch(imdyn + "_set_imaging_target")
+def test_init_objects(*args):
+    ImagingDynModel(MagicMock(simulator=MagicMock()), 1.0)
+    for setter in args:
+        setter.assert_called_once()
+
+
+@patch(imdyn + "requires_env", MagicMock(return_value=[]))
+@patch(imdyn + "_init_dynamics_objects", MagicMock())
+class TestImagingDynModel:
+    def test_storage_properties(self):
+        dyn = ImagingDynModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.storageUnit = MagicMock()
+        dyn.storageUnit.storageUnitDataOutMsg.read.return_value.storageLevel = 50.0
+        dyn.storageUnit.storageCapacity = 100.0
+        assert dyn.storage_level == 50.0
+        assert dyn.storage_level_fraction == 0.5
+
+    @pytest.mark.parametrize(
+        "level,valid",
+        [(10, True), (0, True), (110, False)],
+    )
+    def test_data_storage_valid(self, level, valid):
+        dyn = ImagingDynModel(MagicMock(simulator=MagicMock()), 1.0)
+        dyn.storageUnit = MagicMock()
+        dyn.storageUnit.storageUnitDataOutMsg.read.return_value.storageLevel = level
+        dyn.storageUnit.storageCapacity = 100.0
+        assert dyn.data_storage_valid() == valid
+
+    @patch(module + "partitionedStorageUnit", MagicMock())
+    @pytest.mark.parametrize(
+        "buffers,names,expected",
+        [
+            (3, None, ["0", "1", "2"]),
+            (None, ["a", "b", "c"], ["a", "b", "c"]),
+            (3, ["a", "b", "c"], ["a", "b", "c"]),
+            (2, ["a", "b", "c"], ValueError),
+        ],
+    )
+    def test_set_storage_unit(self, buffers, names, expected):
+        mock_sim = MagicMock()
+        dyn = ImagingDynModel(MagicMock(simulator=mock_sim), 1.0)
+        dyn.instrument = MagicMock()
+        dyn.transmitter = MagicMock()
+        if isinstance(expected, type):
+            with pytest.raises(expected):
+                dyn._set_storage_unit(1000, buffers, names)
+            return
+        dyn._set_storage_unit(1000, buffers, names)
+        dyn.storageUnit.addPartition.assert_has_calls([call(name) for name in expected])
+        dyn.simulator.CreateNewProcess.assert_called_once()
+
+
+class TestGroundStationDynModel:
+    def test_requires_env(self):
+        assert environment.GroundStationEnvModel in GroundStationDynModel.requires_env
+
+    gsdyn = module + "GroundStationDynModel."
+
+    @patch(gsdyn + "requires_env", MagicMock(return_value=[]))
+    @patch(module + "ImagingDynModel._init_dynamics_objects", MagicMock())
+    @patch(gsdyn + "_set_ground_station_locations")
+    def test_init_objects(self, *args):
+        GroundStationDynModel(MagicMock(simulator=MagicMock()), 1.0)
+        for setter in args:
+            setter.assert_called_once()

--- a/tests/unittest/envs/general_satellite_tasking/simulation/test_environment.py
+++ b/tests/unittest/envs/general_satellite_tasking/simulation/test_environment.py
@@ -1,0 +1,169 @@
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.simulation.environment import (
+    BasicEnvironmentModel,
+    EnvironmentModel,
+    GroundStationEnvModel,
+)
+
+module = "bsk_rl.envs.general_satellite_tasking.simulation.environment."
+
+
+class TestEnvironmentModel:
+    @patch(module + "collect_default_args")
+    def test_default_env_args(self, mock_collect):
+        mock_collect.return_value = {"a": 1, "b": 2, "c": 3}
+        assert EnvironmentModel.default_env_args() == {"a": 1, "b": 2, "c": 3}
+
+    @pytest.mark.parametrize(
+        "overwrite,error", [({"c": 4}, False), ({"not_c": 4}, True)]
+    )
+    @patch(module + "collect_default_args")
+    def test_default_sat_args_overwrote(self, mock_collect, overwrite, error):
+        mock_collect.return_value = {"a": 1, "b": 2, "c": 3}
+        if not error:
+            assert EnvironmentModel.default_env_args(**overwrite) == {
+                "a": 1,
+                "b": 2,
+                "c": 4,
+            }
+        else:
+            with pytest.raises(AssertionError):
+                EnvironmentModel.default_env_args(**overwrite)
+
+    @patch.multiple(EnvironmentModel, __abstractmethods__=set())
+    @patch(module + "EnvironmentModel._init_environment_objects")
+    def test_init(self, mock_obj_init):
+        mock_sim = MagicMock()
+        kwargs = dict(a=1, b=2)
+        env = EnvironmentModel(mock_sim, 1.0, **kwargs)
+        mock_sim.CreateNewProcess.assert_called_once()
+        mock_sim.CreateNewTask.assert_called_once()
+        mock_obj_init.assert_called_once_with(**kwargs)
+        assert env.simulator is not mock_sim
+        assert env.simulator == mock_sim
+
+
+class TestBasicEnvironmentModel:
+    basicenv = module + "BasicEnvironmentModel."
+
+    @patch(basicenv + "__init__", MagicMock(return_value=None))
+    def test_PN(self):
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        env.gravFactory = MagicMock()
+        env.body_index = 0
+        msg = env.gravFactory.spiceObject.planetStateOutMsgs.__getitem__
+        msg.return_value.read.return_value.J20002Pfix = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+        assert (env.PN == np.identity(3)).all()
+
+    @patch(basicenv + "__init__", MagicMock(return_value=None))
+    def test_omega_PN_N(self):
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        env.gravFactory = MagicMock()
+        env.body_index = 0
+        msg = env.gravFactory.spiceObject.planetStateOutMsgs.__getitem__
+        msg.return_value.read.return_value.J20002Pfix_dot = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+        msg.return_value.read.return_value.J20002Pfix = [0, -1, 1, 1, 0, -1, -1, 1, 0]
+        assert (env.omega_PN_N == np.array([1, 1, 1])).all()
+
+    @patch(basicenv + "_set_gravity_bodies")
+    @patch(basicenv + "_set_epoch_object")
+    @patch(basicenv + "_set_atmosphere_density_model")
+    @patch(basicenv + "_set_eclipse_object")
+    def test_init_and_delete(self, grav_set, epoch_set, atmos_set, eclipse_set):
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        for setter in (grav_set, epoch_set, atmos_set, eclipse_set):
+            setter.assert_called_once()
+        unload_function = MagicMock()
+        env.gravFactory = MagicMock(unloadSpiceKernels=unload_function)
+        del env
+        unload_function.assert_called_once()
+
+    @patch(basicenv + "_init_environment_objects", MagicMock())
+    @patch(module + "simIncludeGravBody", MagicMock())
+    @patch(
+        module + "pyswice",
+        MagicMock(),
+    )
+    def test_set_gravity_bodies(self):
+        # Smoke test
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        env.simulator = MagicMock()
+        env._set_gravity_bodies(utc_init="time")
+        env.simulator.AddModelToTask.assert_called_once()
+
+    @patch(basicenv + "_init_environment_objects", MagicMock())
+    @patch(module + "ephemerisConverter", MagicMock())
+    def test_set_epoch_object(self):
+        # Smoke test
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        env.simulator = MagicMock()
+        env.gravFactory = MagicMock()
+        env.sun_index = 0
+        env.body_index = 1
+        env._set_epoch_object()
+        env.simulator.AddModelToTask.assert_called_once()
+
+    @patch(basicenv + "_init_environment_objects", MagicMock())
+    @patch(module + "exponentialAtmosphere", MagicMock())
+    def test_set_atmosphere_density_model(self):
+        # Smoke test
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        env.simulator = MagicMock()
+        env.gravFactory = MagicMock()
+        env.body_index = 1
+
+        env._set_atmosphere_density_model(
+            planetRadius=1.0,
+            baseDensity=1.0,
+            scaleHeight=1.0,
+        )
+        env.simulator.AddModelToTask.assert_called_once()
+
+    @patch(basicenv + "_init_environment_objects", MagicMock())
+    @patch(module + "eclipse", MagicMock())
+    def test_set_eclipse_object(self):
+        # Smoke test
+        env = BasicEnvironmentModel(MagicMock(), 1.0)
+        env.simulator = MagicMock()
+        env.gravFactory = MagicMock()
+        env.sun_index = 0
+        env.body_index = 1
+        env._set_eclipse_object()
+        env.simulator.AddModelToTask.assert_called_once()
+
+
+class TestGroundStationEnvModel:
+    groundenv = module + "GroundStationEnvModel."
+
+    @patch(groundenv + "_set_ground_locations")
+    @patch(module + "BasicEnvironmentModel._init_environment_objects", MagicMock())
+    def test_init_environment_objects(self, ground_set):
+        GroundStationEnvModel(MagicMock(), 1.0)
+        ground_set.assert_called_once()
+
+    @patch(groundenv + "_init_environment_objects", MagicMock())
+    @patch(groundenv + "_create_ground_station")
+    def test_set_ground_locations(self, mock_gs_create):
+        env = GroundStationEnvModel(MagicMock(), 1.0)
+        env._set_ground_locations([dict(a=1), dict(b=2)], 1000.0, 1.0, 1000.0)
+        mock_gs_create.assert_has_calls(
+            [call(a=1, priority=1399), call(b=2, priority=1398)]
+        )
+
+    @patch(groundenv + "_init_environment_objects", MagicMock())
+    @patch(module + "groundLocation", MagicMock())
+    def test_create_ground_station(self):
+        env = GroundStationEnvModel(MagicMock(), 1.0)
+        env.simulator = MagicMock()
+        env.gravFactory = MagicMock()
+        env.groundStations = []
+        env.groundLocationPlanetRadius = 10.0
+        env.gsMinimumElevation = 1.0
+        env.gsMaximumRange = 1000.0
+        env.body_index = 1
+        env._create_ground_station(0.0, 0.0)
+        env.simulator.AddModelToTask.assert_called_once()

--- a/tests/unittest/envs/general_satellite_tasking/simulation/test_fsw.py
+++ b/tests/unittest/envs/general_satellite_tasking/simulation/test_fsw.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+from bsk_rl.envs.general_satellite_tasking.simulation.fsw import (
+    BasicFSWModel,
+    FSWModel,
+    Task,
+    action,
+)
+
+module = "bsk_rl.envs.general_satellite_tasking.simulation.fsw."
+
+
+def test_action_decorator():
+    mock_actions = MagicMock()
+
+    class Object(MagicMock):
+        @action
+        def action_function(self, foo, bar=2):
+            mock_actions(foo, bar=bar)
+
+    o = Object()
+    o.tasks = [MagicMock()]
+    o.action_function(3, bar=4)
+    o.fsw_proc.disableAllTasks.assert_called_once()
+    o._zero_gateway_msgs.assert_called_once()
+    o.dynamics.reset_for_action.assert_called_once()
+    o.tasks[0].reset_for_action.assert_called_once()
+    mock_actions.assert_called_once_with(3, bar=4)
+
+
+@patch.multiple(FSWModel, __abstractmethods__=set())
+class TestFSWModel:
+    def test_base_class(self):
+        sat = MagicMock()
+        fsw = FSWModel(sat, 1.0)
+        # fsw.simulator.CreateNewProcess.assert_called_once()
+        assert sat.simulator.environment == fsw.environment
+        assert sat.dynamics == fsw.dynamics
+
+    @patch(module + "check_aliveness_checkers", MagicMock(return_value=True))
+    def test_is_alive(self):
+        fsw = FSWModel(MagicMock(), 1.0)
+        assert fsw.is_alive()
+
+
+@patch.multiple(Task, __abstractmethods__=set())
+class TestTask:
+    def test_base_class(self):
+        fsw = MagicMock()
+        task = Task(fsw, 1)
+        task.create_task()
+        task.fsw.simulator.CreateNewTask.assert_called_once()
+        task.init_objects()
+        task.reset_for_action()
+        task.fsw.simulator.disableTask.assert_called_once()
+
+
+basicfsw = module + "BasicFSWModel."
+
+
+@patch(basicfsw + "requires_dyn", MagicMock(return_value=[]))
+class TestBasicFSWModel:
+    @patch(basicfsw + "_set_messages", MagicMock())
+    @patch(basicfsw + "SunPointTask")
+    @patch(basicfsw + "NadirPointTask")
+    @patch(basicfsw + "RWDesatTask")
+    @patch(basicfsw + "TrackingErrorTask")
+    @patch(basicfsw + "MRPControlTask")
+    def test_make_tasks(self, *args):
+        fsw = BasicFSWModel(MagicMock(), 1)
+        for task in fsw.tasks:
+            task.create_task.assert_called_once()
+            task.create_module_data.assert_called_once()
+            task.init_objects.assert_called_once()

--- a/tests/unittest/envs/general_satellite_tasking/simulation/test_simulator.py
+++ b/tests/unittest/envs/general_satellite_tasking/simulation/test_simulator.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.simulation.simulator import Simulator
+
+
+@patch("Basilisk.utilities.SimulationBaseClass.SimBaseClass.__init__")
+class TestSimulator:
+    dyn = MagicMock()
+    fsw = MagicMock()
+
+    class MockEnv(MagicMock):
+        def __init__(self, sim, rate, **kwargs):
+            super().__init__(**kwargs)
+            self.sim = sim
+            self.rate = rate
+
+    def mock_sim(self, **kwargs):
+        Simulator.InitializeSimulation = MagicMock()
+        Simulator.ConfigureStopTime = MagicMock()
+        Simulator.ExecuteSimulation = MagicMock()
+
+        class MockSat(MagicMock):
+            @property
+            def id(self):
+                return "sat_1"
+
+        sat = MockSat(
+            set_dynamics=MagicMock(return_value=self.dyn),
+            set_fsw=MagicMock(return_value=self.fsw),
+        )
+        sim = Simulator([sat], env_type=self.MockEnv, env_args={}, **kwargs)
+        sim.TotalSim = MagicMock(CurrentNanos=1000000000)
+
+        return sim
+
+    def test_init(self, simbase_init):
+        sim = self.mock_sim()
+        assert sim.dynamics_list == {"sat_1": self.dyn}
+        assert sim.fsw_list == {"sat_1": self.fsw}
+
+    def test_sim_time_ns(self, simbase_init):
+        sim = self.mock_sim()
+        assert sim.sim_time_ns == 1000000000
+
+    def test_sim_time(self, simbase_init):
+        sim = self.mock_sim()
+        assert sim.sim_time == 1.0
+
+    def test_set_environment(self, simbase_init):
+        sim = self.mock_sim()
+        assert sim.environment.sim == sim
+        assert sim.environment.rate == sim.sim_rate
+
+    @pytest.mark.parametrize(
+        "start_time,step_duration,time_limit,stop_time",
+        [(0, 100, 50, 50), (0, 100, 200, 100), (10, 10, 50, 20)],
+    )
+    def test_run(self, simbase_init, start_time, step_duration, time_limit, stop_time):
+        sim = self.mock_sim(max_step_duration=step_duration, time_limit=time_limit)
+        sim.TotalSim.CurrentNanos = start_time * 1000000000
+        sim.run()
+        sim.ConfigureStopTime.assert_called_with(stop_time * 1000000000)

--- a/tests/unittest/envs/general_satellite_tasking/test_gym_env.py
+++ b/tests/unittest/envs/general_satellite_tasking/test_gym_env.py
@@ -1,0 +1,240 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from gymnasium import spaces
+
+from bsk_rl.envs.general_satellite_tasking.gym_env import (
+    GeneralSatelliteTasking,
+    SingleSatelliteTasking,
+)
+from bsk_rl.envs.general_satellite_tasking.scenario.satellites import Satellite
+
+
+class TestGeneralSatelliteTasking:
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.gym_env.GeneralSatelliteTasking.__init__",
+        MagicMock(return_value=None),
+    )
+    def test_generate_env_args(self):
+        env = GeneralSatelliteTasking()
+        env.env_args_generator = {"a": 1, "b": lambda: 2}
+        env._generate_env_args()
+        assert env.env_args == {"a": 1, "b": 2}
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.gym_env.Simulator",
+    )
+    def test_reset(self, mock_sim):
+        mock_sat = MagicMock()
+        mock_sat.sat_args_generator = {}
+        mock_data = MagicMock()
+        env = GeneralSatelliteTasking(
+            satellites=[mock_sat],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=mock_data,
+        )
+        env.env_args_generator = {"utc_init": "a long time ago"}
+        env.communicator = MagicMock()
+        env.reset()
+        assert mock_sat.sat_args_generator["utc_init"] == env.env_args["utc_init"]
+        mock_sim.assert_called_once()
+        mock_sat.reset_pre_sim.assert_called_once()
+        mock_data.create_data_store.assert_called_once_with(mock_sat)
+        env.communicator.reset.assert_called_once()
+        mock_sat.reset_post_sim.assert_called_once()
+
+    def test_get_obs(self):
+        env = GeneralSatelliteTasking(
+            satellites=[MagicMock(get_obs=MagicMock(return_value=i)) for i in range(3)],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        assert env._get_obs() == (0, 1, 2)
+
+    def test_get_info(self):
+        mock_sats = [MagicMock(info={"sat_index": i}) for i in range(3)]
+        env = GeneralSatelliteTasking(
+            satellites=mock_sats,
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        env.latest_step_duration = 10.0
+        expected = {sat.id: {"sat_index": i} for i, sat in enumerate(mock_sats)}
+        expected["d_ts"] = 10.0
+        assert env._get_info() == expected
+
+    def test_action_space(self):
+        env = GeneralSatelliteTasking(
+            satellites=[
+                MagicMock(action_space=spaces.Discrete(i + 1)) for i in range(3)
+            ],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        assert env.action_space == spaces.Tuple(
+            (spaces.Discrete(1), spaces.Discrete(2), spaces.Discrete(3))
+        )
+
+    def test_obs_space_no_sim(self):
+        env = GeneralSatelliteTasking(
+            satellites=[
+                MagicMock(observation_space=spaces.Discrete(i + 1)) for i in range(3)
+            ],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        env.seed = 123
+        old_seed = env.seed
+        env.reset = MagicMock()
+        assert env.observation_space == spaces.Tuple(
+            (spaces.Discrete(1), spaces.Discrete(2), spaces.Discrete(3))
+        )
+        env.reset.assert_called_once_with(seed=old_seed)
+
+    def test_obs_space_existing_sim(self):
+        env = GeneralSatelliteTasking(
+            satellites=[
+                MagicMock(observation_space=spaces.Discrete(i + 1)) for i in range(3)
+            ],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        env.simulator = MagicMock()
+        env.reset = MagicMock()
+        assert env.observation_space == spaces.Tuple(
+            (spaces.Discrete(1), spaces.Discrete(2), spaces.Discrete(3))
+        )
+        env.reset.assert_not_called()
+
+    def test_step(self):
+        mock_sats = [MagicMock() for _ in range(2)]
+        env = GeneralSatelliteTasking(
+            satellites=mock_sats,
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(reward=MagicMock(return_value=25.0)),
+        )
+        env.simulator = MagicMock(sim_time=101.0)
+        _, reward, _, _, info = env.step((0, 10))
+        mock_sats[0].set_action.assert_called_once_with(0)
+        mock_sats[1].set_action.assert_called_once_with(10)
+        env.simulator.run.assert_called_once()
+        assert env.latest_step_duration == 0.0
+        for sat in mock_sats:
+            sat.data_store.internal_update.assert_called_once()
+        assert reward == 25.0
+
+    def test_step_bad_action(self):
+        mock_sats = [MagicMock() for _ in range(2)]
+        env = GeneralSatelliteTasking(
+            satellites=mock_sats,
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(reward=MagicMock(return_value=25.0)),
+        )
+        env.simulator = MagicMock(sim_time=101.0)
+        with pytest.raises(ValueError):
+            env.step((0, 10, 20))
+        with pytest.raises(ValueError):
+            env.step((0,))
+
+    @pytest.mark.parametrize("sat_death", [True, False])
+    @pytest.mark.parametrize("timeout", [True, False])
+    @pytest.mark.parametrize("terminate_on_time_limit", [True, False])
+    def test_step_stopped(self, sat_death, timeout, terminate_on_time_limit):
+        mock_sats = [MagicMock() for _ in range(2)]
+        env = GeneralSatelliteTasking(
+            satellites=mock_sats,
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(reward=MagicMock(return_value=25.0)),
+            terminate_on_time_limit=terminate_on_time_limit,
+        )
+        env.simulator = MagicMock(sim_time=101.0)
+        if timeout:
+            env.time_limit = 100.0
+        else:
+            env.time_limit = 1000.0
+
+        if sat_death:
+            mock_sats[1].is_alive.return_value = False
+
+        _, _, terminated, truncated, _ = env.step((0, 10))
+
+        assert terminated == (sat_death or (timeout and terminate_on_time_limit))
+        assert truncated == timeout
+
+    def test_render(self):
+        pass
+
+    def test_close(self):
+        env = GeneralSatelliteTasking(
+            satellites=[MagicMock()],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        env.simulator = MagicMock()
+        env.close()
+        assert not hasattr(env, "simulator")
+
+
+class TestSingleSatelliteTasking:
+    @patch.multiple(Satellite, __abstractmethods__=set())
+    def test_init(self):
+        mock_sat = Satellite("Sat", {})
+        env = SingleSatelliteTasking(
+            satellites=mock_sat,
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        assert env.satellite == mock_sat
+
+    def test_init_multisat(self):
+        with pytest.raises(AssertionError):
+            SingleSatelliteTasking(
+                satellites=[MagicMock(), MagicMock()],
+                env_type=MagicMock(),
+                env_features=MagicMock(),
+                data_manager=MagicMock(),
+            )
+
+    @staticmethod
+    def make_env():
+        mock_sat = MagicMock()
+        env = SingleSatelliteTasking(
+            satellites=[mock_sat],
+            env_type=MagicMock(),
+            env_features=MagicMock(),
+            data_manager=MagicMock(),
+        )
+        return env, mock_sat
+
+    def test_action_space(self):
+        env, mock_sat = self.make_env()
+        assert env.action_space == mock_sat.action_space
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.gym_env.GeneralSatelliteTasking.observation_space"
+    )
+    def test_observation_space(self, obs_patch):
+        env, mock_sat = self.make_env()
+        env.simulator = MagicMock()
+        assert env.observation_space == mock_sat.observation_space
+
+    @patch("bsk_rl.envs.general_satellite_tasking.gym_env.GeneralSatelliteTasking.step")
+    def test_step(self, step_patch):
+        env, mock_sat = self.make_env()
+        env.step("action")
+        step_patch.assert_called_once_with(["action"])
+
+    def test_get_obs(self):
+        env, mock_sat = self.make_env()
+        assert env._get_obs() == mock_sat.get_obs()

--- a/tests/unittest/envs/general_satellite_tasking/utils/test_debug.py
+++ b/tests/unittest/envs/general_satellite_tasking/utils/test_debug.py
@@ -1,0 +1,6 @@
+from bsk_rl.envs.general_satellite_tasking.utils.debug import MEMORY_LEAK_CHECKING
+
+
+def test_memory_leak_checking():
+    # Ensure leak checking is off by default
+    assert MEMORY_LEAK_CHECKING is False

--- a/tests/unittest/envs/general_satellite_tasking/utils/test_functional.py
+++ b/tests/unittest/envs/general_satellite_tasking/utils/test_functional.py
@@ -1,0 +1,180 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.utils import functional
+
+
+@pytest.mark.parametrize("input", ["valid", "123", "money$", "Hello, world!"])
+def test_valid_valid_func_name(input):
+    assert functional.valid_func_name(input).isidentifier()
+
+
+@pytest.mark.parametrize(
+    "updates,base,expected,warn",
+    [
+        ({"a": 1, "b": 2}, {}, {"a": 1, "b": 2}, False),
+        ({"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 1, "b": 2}, True),
+        ({}, {"a": 1, "b": 2}, {"a": 1, "b": 2}, False),
+        ({"b": 2}, {"a": 1, "b": 4}, {"a": 1, "b": 2}, True),
+        ({"b": 2}, {"a": 1}, {"a": 1, "b": 2}, False),
+        ({}, {}, {}, False),
+    ],
+)
+def test_safe_dict_merge(updates, base, expected, warn):
+    if warn:
+        with pytest.warns():
+            updated = functional.safe_dict_merge(updates, base)
+    else:
+        updated = functional.safe_dict_merge(updates, base)
+    assert updated is base
+    assert updated == expected
+
+
+class TestDefaultArgs:
+    class C1:
+        @functional.default_args(a=1)
+        def foo(self, a):
+            self.a = a
+            return self.a
+
+    class C2:
+        @functional.default_args(b=2)
+        def bar(self, b):
+            self.b = b
+            return self.b
+
+    class C3:
+        @functional.default_args(a=3)
+        def baz(self, a):
+            self.a = a
+            return self.a
+
+    def test_default_args(self):
+        c = self.C1()
+        assert functional.collect_default_args(c) == {"a": 1}
+
+    def test_call(self):
+        c = self.C1()
+        assert c.foo(**functional.collect_default_args(c)) == 1
+
+    def test_default_args_combined(self):
+        class C12(self.C1, self.C2):
+            pass
+
+        c = C12()
+        assert functional.collect_default_args(c) == {"a": 1, "b": 2}
+
+    def test_default_args_overwrite(self):
+        class C13(self.C1, self.C3):
+            pass
+
+        c = C13()
+        with pytest.warns():
+            assert functional.collect_default_args(c) == {"a": 1}
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        ({"a": np.array([1]), "b": 2, "c": [3]}, np.array([1, 2, 3])),
+        ({"a": {"b": 1, "c": 2}, "d": 3}, np.array([1, 2, 3])),
+    ],
+)
+def test_vectorize_nested_dict(input, output):
+    assert np.equal(output, functional.vectorize_nested_dict(input)).all()
+
+
+class TestAlivenessChecker:
+    class Alive(MagicMock):
+        @functional.aliveness_checker
+        def is_alive(self):
+            return True
+
+    class Dead(MagicMock):
+        @functional.aliveness_checker
+        def is_living(self):
+            return False
+
+    class Schrodinger(Alive, Dead):
+        pass
+
+    def test_alive(self):
+        a = self.Alive()
+        assert functional.check_aliveness_checkers(a)
+
+    @pytest.mark.parametrize(
+        "type",
+        [Dead, Schrodinger],
+    )
+    def test_dead(self, type):
+        d = type()
+        d.simulator.sim_time = 0
+        d.satellite.info = []
+        d.satellite.id = "SAT"
+        assert functional.check_aliveness_checkers(d) is False
+        assert d.satellite.info[0] == (0, "failed is_living check")
+
+
+@pytest.mark.parametrize("prop_name,expected", [("prop", True), ("not_a_prop", False)])
+def test_is_property(prop_name, expected):
+    class CalledException(BaseException):
+        pass
+
+    class Class:
+        @property
+        def prop(self):
+            # should not be called when checked
+            raise CalledException
+
+    c = Class()
+    assert functional.is_property(c, prop_name) == expected
+
+
+class TestConfigurable:
+    @functional.configurable
+    class Class:
+        def __init__(self, *, a=1, b=2):
+            self.a = a
+            self.b = b
+
+    ClassConfigured = Class.configure(b=4)
+
+    def test_default(self):
+        tc = self.Class()
+        assert tc.a == 1
+        assert tc.b == 2
+
+    def test_configured(self):
+        tc = self.ClassConfigured()
+        assert tc.a == 1
+        assert tc.b == 4
+
+    def test_configured_overwrite(self):
+        tc = self.ClassConfigured(a=3)
+        assert tc.a == 3
+        assert tc.b == 4
+        tc = self.ClassConfigured(b=2)
+        assert tc.a == 1
+        assert tc.b == 2
+
+    ClassNotConfigured = Class.configure(c=0)
+
+    def test_not_configurable(self):
+        with pytest.raises(KeyError):
+            self.ClassNotConfigured()
+
+
+def test_bind():
+    class Thing:
+        def __init__(self, val):
+            self.val = val
+
+    something = Thing(21)
+
+    def double(self):
+        return 2 * self.val
+
+    functional.bind(something, double)
+    assert something.double() == 42

--- a/tests/unittest/envs/general_satellite_tasking/utils/test_orbital.py
+++ b/tests/unittest/envs/general_satellite_tasking/utils/test_orbital.py
@@ -1,0 +1,131 @@
+import re
+
+import numpy as np
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.utils import orbital
+
+
+class TestRandomOrbit:
+    @pytest.mark.repeat(10)
+    def test_random_orbit(self):
+        oe = orbital.random_orbit(i=None, Omega=None, omega=None, f=None)
+        assert -np.pi <= oe.i <= np.pi
+        assert 0 <= oe.Omega <= 2 * np.pi
+        assert 0 <= oe.omega <= 2 * np.pi
+        assert 0 <= oe.f <= 2 * np.pi
+
+    def test_repeatable(self):
+        np.random.seed(0)
+        oe1 = orbital.random_orbit()
+        np.random.seed(0)
+        oe2 = orbital.random_orbit()
+        assert oe1.f == oe2.f
+
+    def test_units(self):
+        oe = orbital.random_orbit(
+            i=90.0, alt=500, r_body=1000, e=0.1, Omega=90.0, omega=90.0, f=90.0
+        )
+        assert oe.a == 1500000
+        assert oe.e == 0.1
+        assert np.pi / 2 == oe.i == oe.Omega == oe.omega == oe.f
+
+
+class TestRandomEpoch:
+    @pytest.mark.repeat(10)
+    def test_random_epoch(self):
+        assert (
+            re.match(
+                r"\d{4} [A-Z]{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{3} \(UTC\)",
+                orbital.random_epoch(),
+            )
+            is not None
+        )
+
+    def test_repeatable(self):
+        np.random.seed(0)
+        e1 = orbital.random_epoch()
+        np.random.seed(0)
+        e2 = orbital.random_epoch()
+        assert e1 == e2
+
+
+@pytest.mark.parametrize(
+    "r_sat,r_target,expected",
+    [
+        (np.array([2, 0, 0]), np.array([1, 0, 0]), np.pi / 2),
+        (
+            np.array([[1, 1, 0], [2, 0, 0]]),
+            np.array([1, 0, 0]),
+            np.array([0, np.pi / 2]),
+        ),
+    ],
+)
+def test_elevation(r_sat, r_target, expected):
+    assert np.all(orbital.elevation(r_sat, r_target) == expected)
+
+
+class TestTrajectorySimulator:
+    epoch = "2005 JUL 24 20:50:33.771 (UTC)"
+    oe = orbital.random_orbit(i=0.0, omega=0, Omega=0, f=45.0)
+    mu = 0.3986004415e15
+
+    @pytest.mark.parametrize(
+        "kwargs,error",
+        [
+            (dict(rN=[1, 0, 0], vN=[0, 1, 0]), False),
+            (dict(oe=oe, mu=mu), False),
+            (dict(rN=[1, 0, 0], oe=oe), True),
+            (dict(rN=[1, 0, 0], oe=oe, mu=mu), True),
+            (dict(rN=[1, 0, 0], vN=[0, 1, 0], oe=oe), True),
+            (dict(), True),
+        ],
+    )
+    def test_init(self, kwargs, error):
+        if error:
+            with pytest.raises(ValueError):
+                orbital.TrajectorySimulator(self.epoch, **kwargs)
+        else:
+            orbital.TrajectorySimulator(self.epoch, **kwargs)
+
+    @pytest.mark.parametrize(
+        "dt,extend1,extend2",
+        [(30.0, 100.0, 200.0), (40.0, 100.0, 50.0)],
+    )
+    def test_extend_to_and_time_properties(self, dt, extend1, extend2):
+        ts = orbital.TrajectorySimulator(self.epoch, oe=self.oe, mu=self.mu, dt=dt)
+        assert ts.sim_time == 0
+        ts.extend_to(extend1)
+        assert ts.sim_time == dt * np.floor(extend1 / dt)
+        assert (abs(ts.times - np.arange(0, extend1, dt)) < 1e-9).all()
+        ts.extend_to(extend2)
+        assert ts.sim_time == dt * np.floor(max(extend1, extend2) / dt)
+        assert (abs(ts.times - np.arange(0, max(extend1, extend2), dt)) < 1e-9).all()
+
+    def test_eclipse(self):
+        ts = orbital.TrajectorySimulator(self.epoch, oe=self.oe, mu=self.mu, dt=500.0)
+        start_1, end_1 = ts.next_eclipse(0.0)
+        # Verify eclipse start and end are correct (duration is less than 1/2 orbit)
+        assert (end_1 - start_1 % 5700) < 5700 / 2
+        # With chosen params, start out of eclipse
+        assert end_1 > start_1
+        # Go into eclipse
+        start_2, end_2 = ts.next_eclipse(start_1 + 1.0)
+        assert end_2 == end_1  # Soonest close is the same
+        assert abs(start_2 - start_1 - 5700) < 500.0  # Starts are about an orbit apart
+
+    def test_no_eclipse(self):
+        ts = orbital.TrajectorySimulator(
+            self.epoch,
+            oe=orbital.random_orbit(alt=50000, i=90.0, omega=0, Omega=0, f=45.0),
+            mu=self.mu,
+        )
+        assert ts.next_eclipse(0, max_tries=3) == (1.0, 1.0)
+
+    def test_interpolators(self):
+        # Weak tests, could be better
+        ts = orbital.TrajectorySimulator(self.epoch, oe=self.oe, mu=self.mu)
+        assert (ts.r_BN_N(0) == ts.rN_init).all()
+        assert (ts.r_BN_N(0) != ts.r_BN_N(1)).all()
+        ts = orbital.TrajectorySimulator(self.epoch, oe=self.oe, mu=self.mu)
+        assert (ts.r_BP_P(0) != ts.r_BP_P(1)).all()


### PR DESCRIPTION
## Description
Part of #16

Removes action and observation definitions from satellites.py. These should be defined only in sat_actions and sat_observations. Some convenience types are given in satellites.py to replace deleted code.

How should this pull request be reviewed?
- [ ] By commit
- [x] All changes at once

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Refactor only.

- [x] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`

### Test Configuration
 - Python: [e.g. 3.10.1]
-  Basilisk: [e.g. 2.2.0]
 - Plaform: [e.g. Ubuntu 22.08]

# Checklist:

- [ ] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
