### PR TITLE
Issue #46: Ensure downlink baud is negative

### DIFF
--- a/bsk_rl/envs/general_satellite_tasking/simulation/dynamics.py
+++ b/bsk_rl/envs/general_satellite_tasking/simulation/dynamics.py
@@ -613,7 +613,7 @@ class ImagingDynModel(BasicDynamicsModel):
             self.task_name, self.instrument, ModelPriority=priority
         )
 
-    @default_args(transmitterBaudRate=8e6, transmitterNumBuffers=100)
+    @default_args(transmitterBaudRate=-8e6, transmitterNumBuffers=100)
     def _set_transmitter(
         self,
         transmitterBaudRate: float,
@@ -625,11 +625,12 @@ class ImagingDynModel(BasicDynamicsModel):
         """Create the transmitter model.
 
         Args:
-            transmitterBaudRate: Rate of data downlink [baud]
+            transmitterBaudRate: Rate of data downlink. Should be negative. [baud]
             instrumentBaudRate: Image size, used to set packet size [bits]
             transmitterNumBuffers: Number of transmitter buffers
             priority: Model priority.
         """
+        assert transmitterBaudRate <= 0
         self.transmitter = spaceToGroundTransmitter.SpaceToGroundTransmitter()
         self.transmitter.ModelTag = "transmitter" + self.satellite.id
         self.transmitter.nodeBaudRate = transmitterBaudRate  # baud

--- a/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_actions.py
+++ b/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_actions.py
@@ -36,7 +36,7 @@ class TestImagingAndDownlink:
                 imageRateErrorRequirement=0.05,
                 instrumentBaudRate=1.0,
                 dataStorageCapacity=3.0,
-                transmitterBaudRate=1000.0,
+                transmitterBaudRate=-1.0,
             ),
         ),
         env_type=environment.GroundStationEnvModel,
@@ -44,7 +44,7 @@ class TestImagingAndDownlink:
         env_features=StaticTargets(n_targets=1000),
         data_manager=data.NoDataManager(),
         sim_rate=1.0,
-        time_limit=5700.0,
+        time_limit=10000.0,
         max_step_duration=1e9,
         disable_env_checker=True,
     )
@@ -59,7 +59,8 @@ class TestImagingAndDownlink:
 
     def test_downlink(self):
         storage_init = self.env.satellite.dynamics.storage_level
-        self.env.step(0)
+        assert storage_init > 0.0  # Should be filled from previous test
+        self.env.step(0)  # Should encounter a downlink opportunity before timeout
         assert self.env.satellite.dynamics.storage_level < storage_init
 
     def test_image_by_name(self):


### PR DESCRIPTION
## Description
Closes Issue #46

Fix the default baud for downlink to be negative. Enforce that the downlink baud must be negative when setting up models.

How should this pull request be reviewed?
- [ ] By commit
- [x] All changes at once

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Passes previously failing test

- [x] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [x] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: 3.10.11
-  Basilisk: 2.2.1
 - Plaform: MacOS 13.3

# Checklist:

- [x] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
