### PR TITLE
Issue #53: Fix image retasking and window generation

### DIFF
--- a/bsk_rl/envs/general_satellite_tasking/scenario/sat_actions.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/sat_actions.py
@@ -155,11 +155,14 @@ class ImagingActions(DiscreteSatAction, ImagingSatellite):
             Target ID
         """
         if np.issubdtype(type(target), np.integer):
-            self.log_info(f"Target index {target}")
+            self.log_info(f"target index {target} tasked")
 
         target = self.parse_target_selection(target)
         if target.id != prev_action_key:
             self.task_target_for_imaging(target)
+        else:
+            self.enable_target_window(target)
+
         return target.id
 
     def set_action(self, action: Union[int, Target, str]):

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_actions.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_actions.py
@@ -145,10 +145,12 @@ class TestImagingActions:
     def test_image_retask(self, sat_init, target):
         sat = sa.ImagingActions()
         sat.log_info = MagicMock()
+        sat.enable_target_window = MagicMock()
         sat.parse_target_selection = MagicMock(return_value=self.MockTarget())
         sat.task_target_for_imaging = MagicMock()
         sat.image(target, prev_action_key="target_1")
         sat.task_target_for_imaging.assert_not_called()
+        sat.enable_target_window.assert_called()
 
     @patch(
         "bsk_rl.envs.general_satellite_tasking.scenario.sat_actions.DiscreteSatAction.set_action"

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
@@ -344,7 +344,7 @@ class TestImagingSatellite:
         sat.task_target_for_imaging(self.tgt0)
         sat.fsw.action_image.assert_called_once()
         assert sat.fsw.action_image.call_args[0][1].startswith("tgt_0")
-        sat.log_info.assert_called_once()
+        sat.log_info.assert_called()
         sat._update_image_event.assert_called_once()
         assert sat._update_image_event.call_args[0][0] == self.tgt0
         sat._update_timed_terminal_event.assert_called_once()


### PR DESCRIPTION
## Description
Closes Issue #53 

1. Fixes a bug where a trajectory interpolator dt worth of windows would not be calculated due to floating point error that causes an equality condition to fail.
2. Fixes a bug where retaking the same image twice in a row would cause the window close terminal event associated with the window to no be recreated. It may be worth considering a better approach to this in the future (i.e. not deleting terminal events every step)

How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tests adjusted to check for intended windows.

- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: 3.10.11
-  Basilisk: 2.2.1
 - Plaform: MacOS 13.3

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
