### PR TITLE
Issue #56: Custom target state specification

### DIFF
--- a/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_observations.py
+++ b/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_observations.py
@@ -156,8 +156,9 @@ class TestTargetState:
 
     def test_target_state(self):
         observation, info = self.env.reset()
-        assert "tgt_loc_1_normd" in observation["target_obs"]
-        assert "tgt_value_1" in observation["target_obs"]
+        assert "target_1" in observation["target_obs"]
+        assert "priority" in observation["target_obs"]["target_1"]
+        assert "location_normd" in observation["target_obs"]["target_1"]
 
 
 class TestEclipseState:


### PR DESCRIPTION
## Description
Closes Issue #56

Adds the ability to specify what is included in the target state. By default, it is set to include the same data as before. However, the format of the obs_dict is slightly different. No users currently use this part of the obs_dict (to my knowledge) so should be fine. A warning is added for old-style specification of target location.

How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

All tests pass.

- [ ] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [ ] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: 3.10.11
-  Basilisk: 2.2.1
 - Plaform: MacOS 13.3

# Checklist:

- [x] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
