### PR TITLE
Issue #67: Refactor window calculations for generality

### DIFF
--- a/bsk_rl/envs/general_satellite_tasking/scenario/satellites.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/satellites.py
@@ -430,6 +430,14 @@ class AccessSatellite(Satellite):
         """Detect if an exact window has been truncated by the edge of the coarse
         window."""
         endpoints = list(endpoints)
+
+        # Filter endpoints that are too close
+        for i, endpoint in enumerate(endpoints[0:-1]):
+            if abs(endpoint - endpoints[i + 1]) < 1e-6:
+                endpoints[i] = None
+        endpoints = [endpoint for endpoint in endpoints if endpoint is not None]
+
+        # Find pairs
         if len(endpoints) % 2 == 1:
             if candidate_window[0] == computation_window[0]:
                 endpoints.insert(0, computation_window[0])

--- a/bsk_rl/envs/general_satellite_tasking/scenario/satellites.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/satellites.py
@@ -276,7 +276,7 @@ class AccessSatellite(Satellite):
         *args,
         generation_duration: float = 60 * 95 / 10,
         initial_generation_duration: Optional[float] = None,
-        access_dist_threshold: float = 1e6,
+        access_dist_threshold: float = 4e6,
         **kwargs,
     ) -> None:
         """Satellite that can detect access opportunities for ground locations with
@@ -289,7 +289,7 @@ class AccessSatellite(Satellite):
             initial_generation_duration: Duration to initially calculate imaging windows
                 [s]
             access_dist_threshold: Distance bound [m] for evaluating imaging windows
-                more exactly.
+                more exactly. 4e6 will capture >10 elevation windows for a 500 km orbit.
         """
         super().__init__(*args, **kwargs)
         self.generation_duration = generation_duration
@@ -752,7 +752,6 @@ class ImagingSatellite(AccessSatellite):
             and self._image_event_name in self.simulator.eventMap
         ):
             self.simulator.delete_event(self._image_event_name)
-            # self.simulator.eventMap[self._image_event_name].eventActive = False
 
     def parse_target_selection(self, target_query: Union[int, Target, str]):
         """Identify a target based on upcoming target index, Target object, or target

--- a/tests/integration/envs/general_satellite_tasking/scenario/test_int_environment_features.py
+++ b/tests/integration/envs/general_satellite_tasking/scenario/test_int_environment_features.py
@@ -38,6 +38,7 @@ def make_env(env_features):
         time_limit=5700.0,
         max_step_duration=1e9,
         disable_env_checker=True,
+        failure_penalty=0,
     )
     return env
 

--- a/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_observations.py
+++ b/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_observations.py
@@ -191,4 +191,32 @@ class TestEclipseState:
         observation2, reward, terminated, truncated, info = self.env.step(0)
         assert (observation2[0] - observation1[0]) < 0.05
         assert (observation2[1] - observation1[1]) < 0.05
-        assert (observation2[1] - observation1[1]) < 0.05
+
+
+class TestGroundStationState:
+    class GroundSat(
+        sa.DriftAction, so.GroundStationState.configure(n_ahead_observe_downlinks=2)
+    ):
+        dyn_type = dynamics.GroundStationDynModel
+        fsw_type = fsw.ImagingFSWModel
+
+    env = gym.make(
+        "SingleSatelliteTasking-v1",
+        satellites=GroundSat(
+            "Satellite",
+            obs_type=list,
+            sat_args=GroundSat.default_sat_args(oe=random_orbit()),
+        ),
+        env_type=environment.GroundStationEnvModel,
+        env_args=environment.GroundStationEnvModel.default_env_args(),
+        env_features=StaticTargets(n_targets=0),
+        data_manager=data.NoDataManager(),
+        sim_rate=1.0,
+        max_step_duration=5700.0,
+        time_limit=5700.0,
+        disable_env_checker=True,
+    )
+
+    def test_ground_station_state(self):
+        observation, info = self.env.reset()
+        assert sum(observation) > 0  # Check that there are downlink opportunities

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
@@ -151,7 +151,7 @@ class TestTargetState:
             ]
         )
         sat.opportunities = [
-            dict(target=target, window=(10.0, 20.0))
+            dict(target=target, window=(10.0, 20.0), type="target")
             for target in sat.upcoming_targets()
         ]
         sat.simulator = MagicMock(sim_time=5.0)

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
@@ -80,6 +80,14 @@ class TestNormdPropertyState:
         sat.add_prop_function("other_prop", norm=10.0)
         assert sat.obs_dict == {"other_prop_normd": 0.1}
 
+    def test_add_bad_prop(self, sat_init):
+        sat = self.make_mocked_sat()
+        del sat.dynamics.not_a_prop
+        del sat.fsw.not_a_prop
+        sat.add_prop_function("not_a_prop")
+        with pytest.raises(AttributeError):
+            sat.obs_dict
+
 
 @patch.multiple(so.TimeState, __abstractmethods__=set())
 @patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
@@ -117,9 +125,9 @@ class TestTargetState:
     def test_target_state(self, sat_init):
         n_ahead = 2
         sat = so.TargetState(n_ahead_observe=n_ahead)
-        sat.upcoming_targets = MagicMock(
+        sat.find_next_opportunities = MagicMock(
             return_value=[
-                MagicMock(priority=i, location=np.array([0.0, 0.0, 0.0]))
+                dict(target=MagicMock(priority=i, location=np.array([0.0, 0.0, 0.0])))
                 for i in range(n_ahead)
             ]
         )
@@ -185,9 +193,9 @@ class TestTargetState:
                 dict(prop="not_a_prop"),
             ],
         )
-        sat.upcoming_targets = MagicMock(
+        sat.find_next_opportunities = MagicMock(
             return_value=[
-                MagicMock(priority=i, location=np.array([0.0, 0.0, 0.0]))
+                dict(target=MagicMock(priority=i, location=np.array([0.0, 0.0, 0.0])))
                 for i in range(n_ahead)
             ]
         )

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_satellites.py
@@ -149,217 +149,6 @@ class TestSatellite:
         assert sat.dynamics == mock_dyn
 
 
-@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
-@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
-def test_init(mock_init):
-    sats.ImagingSatellite(
-        "TestSat",
-        sat_args={"imageTargetMinimumElevation": 1},
-    )
-    mock_init.assert_called_once()
-
-
-@patch(
-    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__",
-    MagicMock(),
-)
-@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
-class TestImagingSatellite:
-    def make_sat(self):
-        return sats.ImagingSatellite(
-            "TestSat",
-            sat_args={"imageTargetMinimumElevation": 1},
-        )
-
-    @patch(
-        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.reset_pre_sim"
-    )
-    def test_reset_pre_sim(self, mock_reset):
-        sat = self.make_sat()
-        sat.data_store = MagicMock()
-        sat.data_store.env_knowledge.targets = [MagicMock()] * 5
-        sat.sat_args = {}
-        sat.reset_pre_sim()
-        mock_reset.assert_called_once()
-        assert sat.sat_args["transmitterNumBuffers"] == 5
-        assert len(sat.sat_args["bufferNames"]) == 5
-
-    @pytest.mark.parametrize(
-        "gen_duration,time_limit,expected",
-        [(None, float("inf"), 0), (None, 100.0, 100.0), (10.0, 100.0, 10.0)],
-    )
-    @patch(
-        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.reset_post_sim"
-    )
-    def test_reset_post_sim(self, mock_reset, gen_duration, time_limit, expected):
-        sat = self.make_sat()
-        sat.sat_args = {}
-        sat.calculate_additional_windows = MagicMock()
-        sat.initial_generation_duration = gen_duration
-        sat.simulator = MagicMock(time_limit=time_limit)
-        sat.reset_post_sim()
-        mock_reset.assert_called_once()
-        assert sat.initial_generation_duration == expected
-        sat.calculate_additional_windows.assert_called_once()
-
-    tgt0 = Target("tgt_0", location=[0.0, 0.0, 0.0], priority=1.0)
-    tgt1 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
-    tgt2 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
-    windows = {
-        tgt0: [(0.0, 10.0), (20.0, 30.0), (40.0, 50.0)],
-        tgt1: [(10.0, 20.0)],
-        tgt2: [(30.0, 40.0)],
-    }
-    _opportunities = [
-        dict(target=tgt0, window=(0.0, 10.0)),
-        dict(target=tgt1, window=(10.0, 20.0)),
-        dict(target=tgt0, window=(20.0, 30.0)),
-        dict(target=tgt2, window=(30.0, 40.0)),
-        dict(target=tgt0, window=(40.0, 50.0)),
-    ]
-
-    def test_upcoming_windows_unfiltered(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=25.0)
-        sat.opportunities = self._opportunities
-        assert sat.upcoming_windows == {
-            self.tgt0: [(20.0, 30.0), (40.0, 50.0)],
-            self.tgt2: [(30.0, 40.0)],
-        }
-
-    def test_upcoming_windows_filtered(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=25.0)
-        sat.opportunities = self._opportunities
-        sat.data_store = MagicMock(data=MagicMock(imaged=[self.tgt0]))
-        assert sat.upcoming_windows == {
-            self.tgt2: [(30.0, 40.0)],
-        }
-
-    def test_next_windows(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=35.0)
-        sat.opportunities = self._opportunities
-        assert sat.next_windows == {
-            self.tgt0: (40.0, 50.0),
-            self.tgt2: (30.0, 40.0),
-        }
-
-    def test_upcoming_targets(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=35.0)
-        sat.opportunities = self._opportunities
-        assert sat.upcoming_targets(2) == [self.tgt2, self.tgt0]
-
-    def test_no_upcoming_targets(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=35.0)
-        sat.opportunities = self._opportunities
-        assert sat.upcoming_targets(0) == []
-
-    def test_upcoming_targets_pad(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=35.0)
-        sat.opportunities = self._opportunities
-        sat.calculate_additional_windows = MagicMock()
-        assert sat.upcoming_targets(4, pad=True) == [
-            self.tgt2,
-            self.tgt0,
-            self.tgt0,
-            self.tgt0,
-        ]
-
-    def test_upcoming_targets_generate_more(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(sim_time=35.0)
-        sat.opportunities = self._opportunities
-        sat.calculate_additional_windows = MagicMock(
-            side_effect=lambda t: self._opportunities.append(
-                dict(target=self.tgt1, window=(60.0, 70.0))
-            )
-        )
-        assert sat.upcoming_targets(3, pad=True) == [
-            self.tgt2,
-            self.tgt0,
-            self.tgt1,
-        ]
-
-    @patch(
-        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.ImagingSatellite._disable_image_event",
-        MagicMock(),
-    )
-    def test_update_image_event_existing(self):
-        sat = self.make_sat()
-        sat.name = "Sat"
-        tgt = MagicMock(name="tgt")
-        existing_event = valid_func_name(f"image_{sat.id}_{tgt.id}")
-        sat.simulator = MagicMock(
-            eventMap={existing_event: MagicMock(eventActive=False)}
-        )
-        sat._update_image_event(tgt)
-        assert sat.simulator.eventMap[existing_event].eventActive is True
-
-    def test_disable_image_event(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(eventMap={"some_image_event": 1})
-        sat._image_event_name = "some_image_event"
-        sat._disable_image_event()
-        sat.simulator.delete_event.assert_called_with("some_image_event")
-
-    def test_disable_image_event_no_event(self):
-        sat = self.make_sat()
-        sat.simulator = MagicMock(eventMap={"some_event": 1})
-        sat._image_event_name = None
-        sat._disable_image_event()
-        assert not sat.simulator.delete_event.called
-
-    upcoming_targets = [Target(f"tgt_{i}", [0, 0, 0], 1.0) for i in range(20)]
-
-    @pytest.mark.parametrize(
-        "query,expected",
-        [
-            (0, "tgt_0"),
-            (3, "tgt_3"),
-            (upcoming_targets[2].id, "tgt_2"),
-            (upcoming_targets[2], "tgt_2"),
-        ],
-    )
-    def test_parse_target_selection(self, query, expected):
-        sat = self.make_sat()
-        sat.upcoming_targets = lambda x: self.upcoming_targets[0:x]
-        sat.data_store = MagicMock(
-            env_knowledge=MagicMock(targets=self.upcoming_targets)
-        )
-        assert expected == sat.parse_target_selection(query).name
-
-    def test_parse_target_selection_invalid(self):
-        sat = self.make_sat()
-        sat.upcoming_targets = lambda x: self.upcoming_targets[0:x]
-        sat.data_store = MagicMock(
-            env_knowledge=MagicMock(targets=self.upcoming_targets)
-        )
-        with pytest.raises(TypeError):
-            sat.parse_target_selection(np.zeros(10))
-
-    def test_task_target_for_imaging(self):
-        sat = self.make_sat()
-        sat.opportunities = self._opportunities
-        sat.name = "Sat"
-        sat.fsw = MagicMock()
-        sat.simulator = MagicMock(sim_time=35.0)
-        sat._update_image_event = MagicMock()
-        sat._update_timed_terminal_event = MagicMock()
-        sat.log_info = MagicMock()
-        sat.task_target_for_imaging(self.tgt0)
-        sat.fsw.action_image.assert_called_once()
-        assert sat.fsw.action_image.call_args[0][1].startswith("tgt_0")
-        sat.log_info.assert_called()
-        sat._update_image_event.assert_called_once()
-        assert sat._update_image_event.call_args[0][0] == self.tgt0
-        sat._update_timed_terminal_event.assert_called_once()
-        assert sat._update_timed_terminal_event.call_args[0][0] == 50.0
-
-
 @patch(
     "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__",
     MagicMock(),
@@ -367,12 +156,24 @@ class TestImagingSatellite:
 @patch(
     "bsk_rl.envs.general_satellite_tasking.utils.orbital.elevation", lambda x, y: y - x
 )
-@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
-class TestCalculateWindows:
+@patch.multiple(sats.AccessSatellite, __abstractmethods__=set())
+class TestAccessSatellite:
     def make_sat(self):
-        return sats.ImagingSatellite(
+        return sats.AccessSatellite(
             "TestSat",
             sat_args={"imageTargetMinimumElevation": 1},
+        )
+
+    def test_add_location_for_access_checking(self):
+        sat = self.make_sat()
+        sat.locations_for_access_checking = []
+        target = MagicMock()
+        sat.add_location_for_access_checking(
+            object=target, location=[0, 0, 0], min_elev=1.0, type="target"
+        )
+        assert (
+            dict(target=target, location=[0, 0, 0], min_elev=1.0, type="target")
+            in sat.locations_for_access_checking
         )
 
     @pytest.mark.parametrize("start", [0.0, 100.0])
@@ -391,8 +192,7 @@ class TestCalculateWindows:
                 x=np.linspace(0, start + duration), y=np.linspace(0, start + duration)
             ),
         )
-        sat.data_store = MagicMock()
-        sat.data_store.env_knowledge.targets = []
+        sat.locations_for_access_checking = []
         sat.calculate_additional_windows(duration)
         if duration == 0.0:
             return
@@ -404,8 +204,7 @@ class TestCalculateWindows:
         sat = self.make_sat()
         sat.window_calculation_time = 0.0
         sat.opportunities = []
-        sat.min_elev = 1.3
-        sat.target_dist_threshold = 5.0
+        sat.access_dist_threshold = 5.0
         sat.trajectory = MagicMock(
             dt=2.0,
             r_BP_P=MagicMock(
@@ -418,10 +217,11 @@ class TestCalculateWindows:
                 ),
             ),
         )
-        sat.data_store = MagicMock()
-        sat.data_store.env_knowledge.targets = [tgt]
+        sat.locations_for_access_checking = [
+            dict(target=tgt, type="target", min_elev=1.3, location=tgt.location)
+        ]
         sat.calculate_additional_windows(100.0)
-        assert tgt in sat.windows
+        assert tgt in sat.opportunities_dict()
         assert sat.opportunities[0]["window"][0] == approx(
             50 - 0.27762037530835193, abs=1e-2
         )
@@ -552,8 +352,287 @@ class TestCalculateWindows:
     def test_add_window(self, merge_time, tgt, window, expected_window):
         sat = self.make_sat()
         sat.opportunities = [
-            dict(target=self.tgt1, window=(3.0, 8.0)),
-            dict(target=self.tgt0, window=(2.0, 10.0)),
+            dict(target=self.tgt1, window=(3.0, 8.0), type="target"),
+            dict(target=self.tgt0, window=(2.0, 10.0), type="target"),
         ]
-        sat._add_window(tgt, window, merge_time=merge_time)
-        assert expected_window in sat.windows[tgt]
+        sat._add_window(tgt, window, merge_time=merge_time, type="target")
+        assert expected_window in sat.opportunities_dict()[tgt]
+
+    opportunities = [
+        dict(downlink="downObj1", window=(10, 20), type="downlink"),
+        dict(target="tgtObj1", window=(20, 30), type="target"),
+        dict(downlink="downObj1", window=(30, 40), type="downlink"),
+        dict(downlink="downObj2", window=(35, 45), type="downlink"),
+    ]
+
+    def test_upcoming_opportunities(self):
+        sat = self.make_sat()
+        sat.opportunities = self.opportunities
+        sat.simulator = MagicMock(sim_time=25.0)
+        assert sat.upcoming_opportunities == self.opportunities[1:4]
+
+    def test_opportunities_dict(self):
+        sat = self.make_sat()
+        sat.opportunities = self.opportunities
+        assert sat.opportunities_dict(types="target") == dict(tgtObj1=[(20, 30)])
+        assert sat.opportunities_dict(types=None) == sat.opportunities_dict(
+            types=["target", "downlink"]
+        )
+        assert sat.opportunities_dict(types="downlink", filter=["downObj1"]) == dict(
+            downObj2=[(35, 45)]
+        )
+
+    def test_upcoming_opportunities_dict(self):
+        sat = self.make_sat()
+        sat.opportunities = self.opportunities
+        sat.simulator = MagicMock(sim_time=35.0)
+        assert sat.upcoming_opportunities_dict(types="target") == {}
+        assert sat.upcoming_opportunities_dict(
+            types=None
+        ) == sat.upcoming_opportunities_dict(types=["target", "downlink"])
+        assert sat.upcoming_opportunities_dict(
+            types="downlink", filter=["downObj2"]
+        ) == dict(downObj1=[(30, 40)])
+
+    def test_next_opportunities_dict(self):
+        sat = self.make_sat()
+        sat.opportunities = self.opportunities
+        sat.simulator = MagicMock(sim_time=15.0)
+        assert sat.next_opportunities_dict() == dict(
+            downObj1=(10, 20), tgtObj1=(20, 30), downObj2=(35, 45)
+        )
+        assert sat.next_opportunities_dict(types="downlink") == dict(
+            downObj1=(10, 20), downObj2=(35, 45)
+        )
+        assert sat.next_opportunities_dict(filter=["downObj1"]) == dict(
+            tgtObj1=(20, 30), downObj2=(35, 45)
+        )
+
+    def test_find_next_opportunities(self):
+        pass  # Tested in TestImagingSatellite
+
+
+@patch("bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__")
+@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
+def test_init(mock_init):
+    sats.ImagingSatellite(
+        "TestSat",
+        sat_args={"imageTargetMinimumElevation": 1},
+    )
+    mock_init.assert_called_once()
+
+
+@patch(
+    "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.__init__",
+    MagicMock(),
+)
+@patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
+class TestImagingSatellite:
+    def make_sat(self):
+        return sats.ImagingSatellite(
+            "TestSat",
+            sat_args={"imageTargetMinimumElevation": 1},
+        )
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.reset_pre_sim"
+    )
+    def test_reset_pre_sim(self, mock_reset):
+        sat = self.make_sat()
+        sat.data_store = MagicMock()
+        sat.data_store.env_knowledge.targets = [MagicMock()] * 5
+        sat.sat_args = {}
+        sat.reset_pre_sim()
+        mock_reset.assert_called_once()
+        assert sat.sat_args["transmitterNumBuffers"] == 5
+        assert len(sat.sat_args["bufferNames"]) == 5
+
+    @pytest.mark.parametrize(
+        "gen_duration,time_limit,expected",
+        [(None, float("inf"), 0), (None, 100.0, 100.0), (10.0, 100.0, 10.0)],
+    )
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.Satellite.reset_post_sim"
+    )
+    def test_reset_post_sim(self, mock_reset, gen_duration, time_limit, expected):
+        sat = self.make_sat()
+        sat.sat_args = {}
+        sat.calculate_additional_windows = MagicMock()
+        sat.initial_generation_duration = gen_duration
+        sat.simulator = MagicMock(time_limit=time_limit)
+        sat.data_store = MagicMock()
+        sat.reset_post_sim()
+        mock_reset.assert_called_once()
+        assert sat.initial_generation_duration == expected
+        sat.calculate_additional_windows.assert_called_once()
+
+    tgt0 = Target("tgt_0", location=[0.0, 0.0, 0.0], priority=1.0)
+    tgt1 = Target("tgt_1", location=[0.0, 0.0, 0.0], priority=1.0)
+    tgt2 = Target("tgt_2", location=[0.0, 0.0, 0.0], priority=1.0)
+    windows = {
+        tgt0: [(0.0, 10.0), (20.0, 30.0), (40.0, 50.0)],
+        tgt1: [(10.0, 20.0)],
+        tgt2: [(30.0, 40.0)],
+    }
+    opportunities = [
+        dict(target=tgt0, window=(0.0, 10.0), type="target"),
+        dict(target=tgt1, window=(10.0, 20.0), type="target"),
+        dict(target=tgt0, window=(20.0, 30.0), type="target"),
+        dict(target=tgt2, window=(30.0, 40.0), type="target"),
+        dict(target=tgt0, window=(40.0, 50.0), type="target"),
+    ]
+
+    def test_upcoming_windows_unfiltered(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=25.0)
+        sat.opportunities = self.opportunities
+        assert sat.upcoming_windows == {
+            self.tgt0: [(20.0, 30.0), (40.0, 50.0)],
+            self.tgt2: [(30.0, 40.0)],
+        }
+
+    def test_upcoming_windows_filtered(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=25.0)
+        sat.opportunities = self.opportunities
+        sat.data_store = MagicMock(data=MagicMock(imaged=[self.tgt0]))
+        assert sat.upcoming_windows == {
+            self.tgt2: [(30.0, 40.0)],
+        }
+
+    def test_windows(self):
+        sat = self.make_sat()
+        sat.opportunities = self.opportunities
+        assert sat.windows == self.windows
+
+    def test_next_windows(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.opportunities = self.opportunities
+        assert sat.next_windows == {
+            self.tgt0: (40.0, 50.0),
+            self.tgt2: (30.0, 40.0),
+        }
+
+    def test_upcoming_targets(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.opportunities = self.opportunities
+        assert sat.upcoming_targets(2) == [self.tgt2, self.tgt0]
+
+    def test_no_upcoming_targets(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.opportunities = self.opportunities
+        assert sat.upcoming_targets(0) == []
+
+    def test_upcoming_targets_pad(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.opportunities = self.opportunities
+        sat.calculate_additional_windows = MagicMock()
+        assert sat.upcoming_targets(4, pad=True) == [
+            self.tgt2,
+            self.tgt0,
+            self.tgt0,
+            self.tgt0,
+        ]
+
+    def test_upcoming_targets_generate_more(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat.opportunities = self.opportunities
+        sat.calculate_additional_windows = MagicMock(
+            side_effect=lambda t: self.opportunities.append(
+                dict(target=self.tgt1, window=(60.0, 70.0), type="target")
+            )
+        )
+        print(sat.opportunities)
+        print(
+            sat.upcoming_targets(3, pad=True),
+            [
+                self.tgt2,
+                self.tgt0,
+                self.tgt1,
+            ],
+        )
+        assert sat.upcoming_targets(3, pad=True) == [
+            self.tgt2,
+            self.tgt0,
+            self.tgt1,
+        ]
+
+    @patch(
+        "bsk_rl.envs.general_satellite_tasking.scenario.satellites.ImagingSatellite._disable_image_event",
+        MagicMock(),
+    )
+    def test_update_image_event_existing(self):
+        sat = self.make_sat()
+        sat.name = "Sat"
+        tgt = MagicMock(name="tgt")
+        existing_event = valid_func_name(f"image_{sat.id}_{tgt.id}")
+        sat.simulator = MagicMock(
+            eventMap={existing_event: MagicMock(eventActive=False)}
+        )
+        sat._update_image_event(tgt)
+        assert sat.simulator.eventMap[existing_event].eventActive is True
+
+    def test_disable_image_event(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(eventMap={"some_image_event": 1})
+        sat._image_event_name = "some_image_event"
+        sat._disable_image_event()
+        sat.simulator.delete_event.assert_called_with("some_image_event")
+
+    def test_disable_image_event_no_event(self):
+        sat = self.make_sat()
+        sat.simulator = MagicMock(eventMap={"some_event": 1})
+        sat._image_event_name = None
+        sat._disable_image_event()
+        assert not sat.simulator.delete_event.called
+
+    upcoming_targets = [Target(f"tgt_{i}", [0, 0, 0], 1.0) for i in range(20)]
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            (0, "tgt_0"),
+            (3, "tgt_3"),
+            (upcoming_targets[2].id, "tgt_2"),
+            (upcoming_targets[2], "tgt_2"),
+        ],
+    )
+    def test_parse_target_selection(self, query, expected):
+        sat = self.make_sat()
+        sat.upcoming_targets = lambda x: self.upcoming_targets[0:x]
+        sat.data_store = MagicMock(
+            env_knowledge=MagicMock(targets=self.upcoming_targets)
+        )
+        assert expected == sat.parse_target_selection(query).name
+
+    def test_parse_target_selection_invalid(self):
+        sat = self.make_sat()
+        sat.upcoming_targets = lambda x: self.upcoming_targets[0:x]
+        sat.data_store = MagicMock(
+            env_knowledge=MagicMock(targets=self.upcoming_targets)
+        )
+        with pytest.raises(TypeError):
+            sat.parse_target_selection(np.zeros(10))
+
+    def test_task_target_for_imaging(self):
+        sat = self.make_sat()
+        sat.opportunities = self.opportunities
+        sat.name = "Sat"
+        sat.fsw = MagicMock()
+        sat.simulator = MagicMock(sim_time=35.0)
+        sat._update_image_event = MagicMock()
+        sat._update_timed_terminal_event = MagicMock()
+        sat.log_info = MagicMock()
+        sat.task_target_for_imaging(self.tgt0)
+        sat.fsw.action_image.assert_called_once()
+        assert sat.fsw.action_image.call_args[0][1].startswith("tgt_0")
+        sat.log_info.assert_called()
+        sat._update_image_event.assert_called_once()
+        assert sat._update_image_event.call_args[0][0] == self.tgt0
+        sat._update_timed_terminal_event.assert_called_once()
+        assert sat._update_timed_terminal_event.call_args[0][0] == 50.0


### PR DESCRIPTION
## Description
_Closes #67_

Refactors window calcs to be general while maintaining old ImagingSatellite API. Note: `upcoming_opportunities` is the one difference in the ImagingSatellite API.

Adds an upcoming downlink opportunity state. Can configure to include opening time or closing time.

Also addresses a small bug that happens in root finding where the root is found twice at nearly the same point.

How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Added tests for new code. Maintains coverage.

- [x] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: 3.10.11
-  Basilisk: 2.2.1b0
 - Platform: Mac 13.3

# Checklist:

- [x] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
