### PR TITLE
Issue #72: Fixed data_storage_valid check killing simulation

### DIFF
--- a/tests/unittest/envs/general_satellite_tasking/simulation/test_dynamics.py
+++ b/tests/unittest/envs/general_satellite_tasking/simulation/test_dynamics.py
@@ -210,12 +210,20 @@ class TestImagingDynModel:
         assert dyn.storage_level_fraction == 0.5
 
     @pytest.mark.parametrize(
-        "level,valid",
-        [(10, True), (0, True), (110, False)],
+        "level,valid_check,valid",
+        [
+            (10, True, True),
+            (0, True, True),
+            (110, True, False),
+            (100.001, True, True),
+            (10, False, True),
+            (110, False, True),
+        ],
     )
-    def test_data_storage_valid(self, level, valid):
+    def test_data_storage_valid(self, level, valid_check, valid):
         dyn = ImagingDynModel(MagicMock(simulator=MagicMock()), 1.0)
         dyn.storageUnit = MagicMock()
+        dyn.storageUnitValidCheck = valid_check
         dyn.storageUnit.storageUnitDataOutMsg.read.return_value.storageLevel = level
         dyn.storageUnit.storageCapacity = 100.0
         assert dyn.data_storage_valid() == valid


### PR DESCRIPTION
## Description
Closes issue #72

Now data_storage_valid check does not kill the simulation when data storage level is equal to storage capacity. Added check to verify if the storage level is equal to storage capacity within a tolerance. Also, it is possible to set storageUnitValidCheck to False to avoid storage level checking.

How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: [3.11.5]
-  Basilisk: [2.2.1]
 - Platform: [MacOS 13.5.2]

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
