### PR TITLE
Issue #85: Set initial storage level

### DIFF
--- a/bsk_rl/envs/general_satellite_tasking/simulation/dynamics.py
+++ b/bsk_rl/envs/general_satellite_tasking/simulation/dynamics.py
@@ -841,12 +841,15 @@ class ContinuousImagingDynModel(ImagingDynModel):
             self.task_name, self.instrument, ModelPriority=priority
         )
 
-    @default_args(dataStorageCapacity=20 * 8e6, storageUnitValidCheck=True)
+    @default_args(
+        dataStorageCapacity=20 * 8e6, storageUnitValidCheck=True, storageInit=0
+    )
     def _set_storage_unit(
         self,
         dataStorageCapacity: int,
         priority: int = 699,
         storageUnitValidCheck: bool = True,
+        storageInit: int = 0,
         **kwargs,
     ) -> None:
         """Configure the storage unit and its buffers.
@@ -856,6 +859,7 @@ class ContinuousImagingDynModel(ImagingDynModel):
             priority: Model priority.
             storageUnitValidCheck: If True, check that the storage level is below the
                 storage capacity.
+            setStorageInit: Initial storage level [bits]
         """
         self.storageUnit = simpleStorageUnit.SimpleStorageUnit()
         self.storageUnit.ModelTag = "storageUnit" + self.satellite.id
@@ -863,6 +867,7 @@ class ContinuousImagingDynModel(ImagingDynModel):
         self.storageUnit.addDataNodeToModel(self.instrument.nodeDataOutMsg)
         self.storageUnit.addDataNodeToModel(self.transmitter.nodeDataOutMsg)
         self.storageUnitValidCheck = storageUnitValidCheck
+        self.storageUnit.setDataBuffer(storageInit)
 
         # Add the storage unit to the transmitter
         self.transmitter.addStorageUnitToTransmitter(


### PR DESCRIPTION
## Description
_Closes #85_

An extra argument was added to the _set_storage_unit method in the ContinuousImagingDynModel class to allowing the user to specify the initial storage level.

How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: [3.11.5]
-  Basilisk: [2.2.1]
 - Platform: [MacOs 13.6.2]

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
