### PR TITLE
Issue #18: Maintain current action by selecting None action

### DIFF
--- a/bsk_rl/envs/general_satellite_tasking/scenario/satellites.py
+++ b/bsk_rl/envs/general_satellite_tasking/scenario/satellites.py
@@ -35,6 +35,8 @@ from bsk_rl.envs.general_satellite_tasking.utils.orbital import (
 SatObs = Any
 SatAct = Any
 
+REQUIRES_RETASKING = "REQUIRES_RETASKING"
+
 
 class Satellite(ABC):
     dyn_type: type["DynamicsModel"]  # Type of dynamics model used by this satellite
@@ -153,7 +155,7 @@ class Satellite(ABC):
 
     def reset_post_sim(self) -> None:
         """Called in environment reset, after simulator initialization"""
-        pass
+        self.info.append(REQUIRES_RETASKING)
 
     @property
     def observation_space(self) -> spaces.Box:
@@ -235,6 +237,7 @@ class Satellite(ABC):
             [f"self.TotalSim.CurrentNanos * {macros.NANO2SEC} >= {t_close}"],
             [
                 self._info_command(f"timed termination at {t_close:.1f} " + info),
+                self._satellite_command + f".info.append('{REQUIRES_RETASKING}')",
             ]
             + extra_actions,
             terminal=self.variable_interval,
@@ -747,6 +750,7 @@ class ImagingSatellite(AccessSatellite):
                 [
                     self._info_command(f"imaged {target}"),
                     self._satellite_command + ".imaged += 1",
+                    self._satellite_command + f".info.append('{REQUIRES_RETASKING}')",
                 ],
                 terminal=self.variable_interval,
             )

--- a/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
+++ b/tests/unittest/envs/general_satellite_tasking/scenario/test_sat_observations.py
@@ -100,12 +100,14 @@ class TestTimeState:
 
     def test_explicit_normalization(self, sat_init):
         sat = so.TimeState(normalization_time=10.0)
+        sat.info = MagicMock()
         sat.simulator = MagicMock(sim_time=1.0)
         sat.reset_post_sim()
         assert sat.normalized_time() == 0.1
 
     def test_implicit_normalization(self, sat_init):
         sat = so.TimeState(normalization_time=None)
+        sat.info = MagicMock()
         sat.simulator = MagicMock(sim_time=1.0, time_limit=10.0)
         sat.reset_post_sim()
         assert sat.normalized_time() == 0.1


### PR DESCRIPTION
## Description
Closes #18

Allows actions to add `RETASKING_REQUIRED` to info on action completion. If it is present, the user should assign a new task (currently only a print statement alerts this, didn't want to use warn so it isn't surpressed; maybe we should add a logger eventually?).  If the symbol is not present, the user may task `None` to continue the current task.

This is generally useful in variable-interval, multiagent systems; if one satellite finishes a task, the step will end; it may be desirable to have other satellites continue their current action rather than retask.

How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tests still pass, new tests added.

- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`

### Test Configuration
 - Python: 3.10.11
-  Basilisk: 2.2.1b
 - Platform: MacOS 13.3.1

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
