### PR TITLE
Issue #58: Expose state vector element names

### DIFF
--- a/src/bsk_rl/envs/general_satellite_tasking/scenario/sat_observations.py
+++ b/src/bsk_rl/envs/general_satellite_tasking/scenario/sat_observations.py
@@ -53,7 +53,14 @@ class SatObservation(Satellite):
     @property
     def obs_ndarray(self):
         """Numpy vector observation format."""
-        return vectorize_nested_dict(self.obs_dict)
+        _, obs = vectorize_nested_dict(self.obs_dict)
+        return obs
+
+    @property
+    def obs_array_keys(self):
+        """Utility to get the keys of the obs_ndarray."""
+        keys, _ = vectorize_nested_dict(self.obs_dict)
+        return keys
 
     @property
     def obs_list(self):

--- a/tests/unittest/envs/general_satellite_tasking/utils/test_functional.py
+++ b/tests/unittest/envs/general_satellite_tasking/utils/test_functional.py
@@ -76,14 +76,24 @@ class TestDefaultArgs:
 
 
 @pytest.mark.parametrize(
-    "input,output",
+    "input,outkeys,outvec",
     [
-        ({"a": np.array([1]), "b": 2, "c": [3]}, np.array([1, 2, 3])),
-        ({"a": {"b": 1, "c": 2}, "d": 3}, np.array([1, 2, 3])),
+        (
+            {"alpha": np.array([1]), "b": 2, "c": [3]},
+            ["alpha[0]", "b", "c[0]"],
+            np.array([1, 2, 3]),
+        ),
+        (
+            {"a": {"b": 1, "charlie": 2}, "d": 3},
+            ["a.b", "a.charlie", "d"],
+            np.array([1, 2, 3]),
+        ),
     ],
 )
-def test_vectorize_nested_dict(input, output):
-    assert np.equal(output, functional.vectorize_nested_dict(input)).all()
+def test_vectorize_nested_dict(input, outkeys, outvec):
+    keys, vec = functional.vectorize_nested_dict(input)
+    assert np.equal(outvec, vec).all()
+    assert outkeys == keys
 
 
 class TestAlivenessChecker:


### PR DESCRIPTION
## Description
Closes #58

Allows the user to print out a list of state names from sat observations. Can only be produced after environment initialization,  since the shape of each observation element is unknown until then. For example
```
Observation: [ 5.55643668e-04 -8.20527293e-04 -2.82089986e-03  1.30471109e-03
              -2.84886806e-05  9.99999148e-01  5.31311297e-01 -5.76592276e-01
              -7.38774349e-01  5.67862249e-01  7.45917635e-01 -1.73853876e-01
               9.84419538e-01  4.82351662e-01  7.87235656e-01  2.62243219e-01
              -5.58111562e-01  6.60252514e-01  7.85183742e-01  2.64519689e-01
              -5.59924839e-01  4.17639105e-01  7.78825097e-01  2.71977900e-01
              -5.65207475e-01  3.44327485e-01]
States: ['omega_BP_P_normd[0]', 'omega_BP_P_normd[1]', 'omega_BP_P_normd[2]', 
         'c_hat_P[0]', 'c_hat_P[1]', 'c_hat_P[2]', 'r_BN_P_normd[0]', 'r_BN_P_normd[1]', 
         'r_BN_P_normd[2]', 'v_BN_P_normd[0]', 'v_BN_P_normd[1]', 'v_BN_P_normd[2]', 
         'battery_charge_fraction', 'target_obs.target_0.priority', 
         'target_obs.target_0.location_normd[0]',  'target_obs.target_0.location_normd[1]', 
         'target_obs.target_0.location_normd[2]',  'target_obs.target_1.priority', 
         'target_obs.target_1.location_normd[0]', 'target_obs.target_1.location_normd[1]', 
         'target_obs.target_1.location_normd[2]', 'target_obs.target_2.priority', 
         'target_obs.target_2.location_normd[0]', 'target_obs.target_2.location_normd[1]',
         'target_obs.target_2.location_normd[2]', 'normalized_time']
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`
- [X] __Examples__ (General Environment only) `pytest tests/examples`

### Test Configuration
- Python: 3.11
- Basilisk: 2.2.2
- Platform: MacOS

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
