### PR TITLE
Issue #116: Add observation of angle between instrument and target

### DIFF
--- a/src/bsk_rl/envs/general_satellite_tasking/scenario/sat_observations.py
+++ b/src/bsk_rl/envs/general_satellite_tasking/scenario/sat_observations.py
@@ -200,6 +200,7 @@ class TargetState(SatObservation, ImagingSatellite):
                 * window_open
                 * window_mid
                 * window_close
+                * target_angle
             args: Passed through to satellite
             kwargs: Passed through to satellite
         """
@@ -246,6 +247,17 @@ class TargetState(SatObservation, ImagingSatellite):
                         value = sum(opportunity["window"]) / 2 - self.simulator.sim_time
                     elif name == "window_close":
                         value = opportunity["window"][1] - self.simulator.sim_time
+                    elif name == "target_angle":
+                        vector_target_spacecraft_P = (
+                            opportunity["target"].location - self.dynamics.r_BN_P
+                        )
+                        vector_target_spacecraft_P_hat = (
+                            vector_target_spacecraft_P
+                            / np.linalg.norm(vector_target_spacecraft_P)
+                        )
+                        value = np.arccos(
+                            np.dot(vector_target_spacecraft_P_hat, self.fsw.c_hat_P)
+                        )
                     else:
                         raise ValueError(
                             f"Invalid target property: {prop_spec['prop']}"


### PR DESCRIPTION
## Description
Closes #116 

Now it is possible to add the angle between the sensing instrument and the target in the observations using the `target_angle` option.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`
- [X] __Examples__ (General Environment only) `pytest tests/examples`

### Test Configuration
- Python: 3.11.6
- Basilisk: 2.2.2
- Platform: MacOS Sonoma 14.2.1

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
