### PR TITLE
Issue #119: Add option to set initial data storage level in ImagingDy…

### DIFF
--- a/src/bsk_rl/envs/general_satellite_tasking/simulation/dynamics.py
+++ b/src/bsk_rl/envs/general_satellite_tasking/simulation/dynamics.py
@@ -745,7 +745,10 @@ class ImagingDynModel(BasicDynamicsModel):
         self.powerMonitor.addPowerNodeToModel(self.transmitterPowerSink.nodePowerOutMsg)
 
     @default_args(
-        dataStorageCapacity=20 * 8e6, bufferNames=None, storageUnitValidCheck=True
+        dataStorageCapacity=20 * 8e6,
+        bufferNames=None,
+        storageUnitValidCheck=True,
+        storageInit=0,
     )
     def _set_storage_unit(
         self,
@@ -754,6 +757,7 @@ class ImagingDynModel(BasicDynamicsModel):
         bufferNames: Optional[Iterable[str]] = None,
         priority: int = 699,
         storageUnitValidCheck: bool = True,
+        storageInit: int = 0,
         **kwargs,
     ) -> None:
         """Configure the storage unit and its buffers.
@@ -766,6 +770,7 @@ class ImagingDynModel(BasicDynamicsModel):
             priority: Model priority.
             storageUnitValidCheck: If True, check that the storage level is below the
                 storage capacity.
+            storageInit: Initial storage level [bits]
             kwargs: Ignored
         """
         self.storageUnit = partitionedStorageUnit.PartitionedStorageUnit()
@@ -787,6 +792,9 @@ class ImagingDynModel(BasicDynamicsModel):
                 )
             for buffer_name in bufferNames:
                 self.storageUnit.addPartition(buffer_name)
+
+        if storageInit != 0:
+            self.storageUnit.setDataBuffer(["STORED DATA"], [int(storageInit)])
 
         # Add the storage unit to the transmitter
         self.transmitter.addStorageUnitToTransmitter(

--- a/tests/integration/envs/general_satellite_tasking/simulation/test_int_dynamics.py
+++ b/tests/integration/envs/general_satellite_tasking/simulation/test_int_dynamics.py
@@ -1,1 +1,112 @@
-# For dynamics models not tested in other tests
+import gymnasium as gym
+import pytest
+
+from bsk_rl.envs.general_satellite_tasking.scenario import data
+from bsk_rl.envs.general_satellite_tasking.scenario import sat_actions as sa
+from bsk_rl.envs.general_satellite_tasking.scenario import sat_observations as so
+from bsk_rl.envs.general_satellite_tasking.scenario.environment_features import (
+    StaticTargets,
+)
+from bsk_rl.envs.general_satellite_tasking.simulation import dynamics, environment, fsw
+from bsk_rl.envs.general_satellite_tasking.utils.orbital import random_orbit
+
+###########################
+# Composed Dynamics Tests #
+###########################
+
+
+class TestImagingDynModelStorage:
+
+    @pytest.mark.parametrize(
+        "storage_capacity, initial_storage",
+        [
+            (8e7, -1),
+            (8e7, 0),
+            (8e7, 8e6),
+            (10e7, 10e7),
+            (8e7, 10e7),
+        ],
+    )
+    def test_storageInit(self, storage_capacity, initial_storage):
+
+        class ImageSat(
+            sa.ImagingActions,
+            sa.DownlinkAction,
+            so.TimeState,
+        ):
+            dyn_type = dynamics.ImagingDynModel
+            fsw_type = fsw.ImagingFSWModel
+
+        env = gym.make(
+            "SingleSatelliteTasking-v1",
+            satellites=ImageSat(
+                "EO-1",
+                n_ahead_act=10,
+                sat_args=ImageSat.default_sat_args(
+                    oe=random_orbit,
+                    dataStorageCapacity=storage_capacity,
+                    storageInit=initial_storage,
+                ),
+            ),
+            env_type=environment.GroundStationEnvModel,
+            env_args=environment.GroundStationEnvModel.default_env_args(),
+            env_features=StaticTargets(n_targets=1000),
+            data_manager=data.NoDataManager(),
+            sim_rate=1.0,
+            time_limit=10000.0,
+            max_step_duration=1e9,
+            disable_env_checker=True,
+        )
+
+        env.reset()
+
+        if initial_storage > storage_capacity or initial_storage < 0:
+            assert env.satellite.dynamics.storage_level == 0
+        else:
+            assert env.satellite.dynamics.storage_level == initial_storage
+
+    @pytest.mark.parametrize(
+        "storage_capacity, initial_storage",
+        [
+            (8e7, 8e6),
+            (10e7, 10e7),
+        ],
+    )
+    def test_storageInit_downlink(self, storage_capacity, initial_storage):
+
+        class ImageSat(
+            sa.DownlinkAction,
+            so.TimeState,
+        ):
+            dyn_type = dynamics.FullFeaturedDynModel
+            fsw_type = fsw.ImagingFSWModel
+
+        env = gym.make(
+            "SingleSatelliteTasking-v1",
+            satellites=ImageSat(
+                "EO-1",
+                n_ahead_act=10,
+                sat_args=ImageSat.default_sat_args(
+                    oe=random_orbit,
+                    dataStorageCapacity=storage_capacity,
+                    storageInit=initial_storage,
+                ),
+            ),
+            env_type=environment.GroundStationEnvModel,
+            env_args=environment.GroundStationEnvModel.default_env_args(),
+            env_features=StaticTargets(n_targets=1000),
+            data_manager=data.NoDataManager(),
+            sim_rate=1.0,
+            time_limit=10000.0,
+            max_step_duration=1e9,
+            disable_env_checker=True,
+        )
+
+        env.reset()
+
+        terminated = False
+        truncated = False
+        while not terminated and not truncated:
+            observation, reward, terminated, truncated, info = env.step(0)
+
+        assert env.satellite.dynamics.storage_level < initial_storage


### PR DESCRIPTION
## Description
Closes #119 

Adds option to set the initial data storage level in ImagingDynModel.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`
- [X] __Examples__ (General Environment only) `pytest tests/examples`

### Test Configuration
- Python: 3.11.6
- Basilisk: 2.2.2
- Platform:  MacOS Sonoma 14.3.1

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
