### PR TITLE
Issue #118: Enforce pytest 7.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pettingzoo",
-    "pytest",
+    "pytest==7.3.1",
     "pytest-cov",
     "pytest-repeat",
     "requests",


### PR DESCRIPTION
## Description
Part of #118 

Pytest 8.X.X causes some tests to break. Pin pytest version until better fix is made.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

### Passes Tests
- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`
- [X] __Examples__ (General Environment only) `pytest tests/examples`

### Test Configuration
- Python: 3.10.11
- Basilisk: 2.3.X
- Platform: MacOS

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
