### PR TITLE
Bugfix/128 force action desat reset

### DIFF
--- a/src/bsk_rl/envs/general_satellite_tasking/scenario/sat_actions.py
+++ b/src/bsk_rl/envs/general_satellite_tasking/scenario/sat_actions.py
@@ -97,12 +97,15 @@ class DiscreteSatAction(SatAction):
         return spaces.Discrete(len(self.action_list))
 
 
-def fsw_action_gen(fsw_action: str, action_duration: float = 1e9) -> type:
+def fsw_action_gen(
+    fsw_action: str, action_duration: float = 1e9, always_reset: bool = False
+) -> type:
     """Generate an action class for a FSW @action.
 
     Args:
         fsw_action: Function name of FSW action.
         action_duration: Time to task action for.
+        always_reset: Reset action if selected more than once in a row.
 
     Returns:
         Satellite action class with fsw_action action.
@@ -138,7 +141,7 @@ def fsw_action_gen(fsw_action: str, action_duration: float = 1e9) -> type:
                 self._update_timed_terminal_event(
                     self.simulator.sim_time + duration, info=f"for {fsw_action}"
                 )
-                if prev_action_key != fsw_action:
+                if prev_action_key != fsw_action or always_reset:
                     getattr(self.fsw, fsw_action)()
                 return fsw_action
 
@@ -159,7 +162,7 @@ ChargingAction = fsw_action_gen("action_charge")
 DriftAction = fsw_action_gen("action_drift")
 
 # Points in a specified direction while firing desat thrusters and desaturating wheels
-DesatAction = fsw_action_gen("action_desat")
+DesatAction = fsw_action_gen("action_desat", always_reset=True)
 
 # Points nadir while downlinking data
 DownlinkAction = fsw_action_gen("action_downlink")

--- a/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_actions.py
+++ b/tests/integration/envs/general_satellite_tasking/scenario/test_int_sat_actions.py
@@ -139,7 +139,7 @@ class TestDesatAction:
             data_manager=data.NoDataManager(),
             sim_rate=1.0,
             max_step_duration=300.0,
-            time_limit=300.0,
+            time_limit=1200.0,
             disable_env_checker=True,
         )
 
@@ -147,10 +147,11 @@ class TestDesatAction:
         env = self.make_env()
         env.reset()
         init_speeds = env.satellite.dynamics.wheel_speeds
-        env.step(0)  # Desat
-        assert np.linalg.norm(env.satellite.dynamics.wheel_speeds) < np.linalg.norm(
-            init_speeds
-        )
+        for _ in range(4):
+            env.step(0)
+            current_speeds = env.satellite.dynamics.wheel_speeds
+            assert np.linalg.norm(current_speeds) < np.linalg.norm(init_speeds)
+            init_speeds = current_speeds
 
     def test_desat_action_power_draw(self):
         env = self.make_env()


### PR DESCRIPTION
## Description
Closes #128 

Action_desat was not reducing reaction wheels' momentum if called more than once in a row. This change forces a reset of the action_desat every time it is tasked, resulting in the expected behavior.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ (General Environment only) `pytest --cov bsk_rl/envs/general_satellite_tasking --cov-report term-missing tests/integration`
- [X] __Examples__ (General Environment only) `pytest tests/examples`

### Test Configuration
- Python: 3.11.6
- Basilisk: 2.2.2
- Platform: MacOs 14.4.1

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
