### PR TITLE
scenario not defined on init

### DIFF
--- a/examples/rllib_training.ipynb
+++ b/examples/rllib_training.ipynb
@@ -171,6 +171,7 @@
     "class CustomDataCallbacks(EpisodeDataCallbacks):\n",
     "    def pull_env_metrics(self, env):\n",
     "        reward = env.rewarder.cum_reward\n",
+    "        reward = sum(reward.values()) / len(reward)\n",
     "        orbits = env.simulator.sim_time / (95 * 60)\n",
     "\n",
     "        data = dict(\n",
@@ -232,7 +233,7 @@
     "        metrics_episode_collection_timeout_s=180,\n",
     "    )\n",
     "    .checkpointing(export_native_model_files=True)\n",
-    "    .framework(framework=\"tf2\")\n",
+    "    .framework(framework=\"torch\")\n",
     ")"
    ]
   },
@@ -243,7 +244,16 @@
     "Once the PPO configuration has been set, `ray` can be started and the agent can be\n",
     "trained.\n",
     "\n",
-    "```python\n",
+    "Training on a reasonably modern machine, we can achieve 5M steps over 32 processors in 6\n",
+    "to 18 hours, depending on specific environment configurations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ray\n",
     "\n",
     "ray.init(\n",
@@ -252,18 +262,19 @@
     "    object_store_memory=2_000_000_000,  # 2 GB\n",
     ")\n",
     "\n",
-    "ppo = PPO(config)\n",
+    "from ray import tune\n",
     "\n",
-    "# Train the policy as you see fit\n",
-    "for _ in range(10):\n",
-    "    ppo.train()\n",
-    "    ppo.checkpoint()\n",
+    "# Run the training\n",
+    "tune.run(\n",
+    "    \"PPO\",\n",
+    "    config=config.to_dict(),\n",
+    "    stop={\"training_iteration\": 500},  # Adjust the number of iterations as needed\n",
+    "    checkpoint_freq=10,\n",
+    "    checkpoint_at_end=True\n",
+    ")\n",
     "\n",
-    "ray.shutdown()\n",
-    "```\n",
-    "\n",
-    "Training on a reasonably modern machine, we can achieve 5M steps over 32 processors in 6\n",
-    "to 18 hours, depending on specific environment configurations."
+    "# Shutdown Ray\n",
+    "ray.shutdown()"
    ]
   },
   {
@@ -301,7 +312,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv_refactor",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -315,9 +326,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/bsk_rl/data/nadir_data.py
+++ b/src/bsk_rl/data/nadir_data.py
@@ -93,10 +93,13 @@ class ScanningTimeReward(GlobalReward):
                 is set to the time spent scanning times ``scenario.value_per_second``.
         """
         super().__init__()
-        if reward_fn is None:
-            reward_fn = lambda t: t * self.scenario.value_per_second
+        self._reward_fn = reward_fn
 
-        self.reward_fn = reward_fn
+    @property
+    def reward_fn(self):
+        if self._reward_fn is None:
+            return lambda t: t * self.scenario.value_per_second
+        return self._reward_fn
 
     def calculate_reward(
         self, new_data_dict: dict[str, "ScanningTime"]


### PR DESCRIPTION
## ScanningTimeReward and scenario init order 

When using the rllib training example, the scenario is not added to the  ScanningTimeReward until GeneralSatelliteTasking calls link. Also added the ppo train call to the example notebook. The reward is also a dict not a float to take the average, which seem like what was intended, but dose not matter with one satellite. 

Closes #147

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

### How should this pull request be reviewed?
- [ ] By commit

## How Has This Been Tested?

Just running the example, with 

Please describe the tests that you ran to verify your changes.

### Passes Tests
Have not got the unit tests working in my env