### PR TITLE
PPO Example

### DIFF
--- a/docs/build/doctrees/nbsphinx/examples/rllib_training.ipynb
+++ b/docs/build/doctrees/nbsphinx/examples/rllib_training.ipynb
@@ -32,10 +32,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T20:59:41.365086Z",
-     "iopub.status.busy": "2024-05-31T20:59:41.364918Z",
-     "iopub.status.idle": "2024-05-31T20:59:42.280245Z",
-     "shell.execute_reply": "2024-05-31T20:59:42.279937Z"
+     "iopub.execute_input": "2024-06-21T22:52:54.266622Z",
+     "iopub.status.busy": "2024-06-21T22:52:54.266424Z",
+     "iopub.status.idle": "2024-06-21T22:52:55.171269Z",
+     "shell.execute_reply": "2024-06-21T22:52:55.170987Z"
     }
    },
    "outputs": [],
@@ -79,6 +79,7 @@
     "            type=\"ground_station\",\n",
     "            n_ahead_observe=1,\n",
     "        ),\n",
+    "        obs.Time(),\n",
     "    ]\n",
     "    action_spec = [\n",
     "        act.Scan(duration=180.0),\n",
@@ -103,10 +104,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T20:59:42.282097Z",
-     "iopub.status.busy": "2024-05-31T20:59:42.281947Z",
-     "iopub.status.idle": "2024-05-31T20:59:42.285198Z",
-     "shell.execute_reply": "2024-05-31T20:59:42.284950Z"
+     "iopub.execute_input": "2024-06-21T22:52:55.173075Z",
+     "iopub.status.busy": "2024-06-21T22:52:55.172941Z",
+     "iopub.status.idle": "2024-06-21T22:52:55.176251Z",
+     "shell.execute_reply": "2024-06-21T22:52:55.176015Z"
     }
    },
    "outputs": [],
@@ -151,15 +152,15 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T20:59:42.286571Z",
-     "iopub.status.busy": "2024-05-31T20:59:42.286488Z",
-     "iopub.status.idle": "2024-05-31T20:59:42.288158Z",
-     "shell.execute_reply": "2024-05-31T20:59:42.287921Z"
+     "iopub.execute_input": "2024-06-21T22:52:55.177626Z",
+     "iopub.status.busy": "2024-06-21T22:52:55.177528Z",
+     "iopub.status.idle": "2024-06-21T22:52:55.179154Z",
+     "shell.execute_reply": "2024-06-21T22:52:55.178938Z"
     }
    },
    "outputs": [],
    "source": [
-    "duration = 3 * 5700.0\n",
+    "duration = 2 * 5700.0  # About 2 orbits\n",
     "env_args = dict(\n",
     "    satellite=sat,\n",
     "    scenario=scene.UniformNadirScanning(value_per_second=1/duration),\n",
@@ -186,10 +187,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T20:59:42.289431Z",
-     "iopub.status.busy": "2024-05-31T20:59:42.289344Z",
-     "iopub.status.idle": "2024-05-31T20:59:48.791034Z",
-     "shell.execute_reply": "2024-05-31T20:59:48.790692Z"
+     "iopub.execute_input": "2024-06-21T22:52:55.180399Z",
+     "iopub.status.busy": "2024-06-21T22:52:55.180310Z",
+     "iopub.status.idle": "2024-06-21T22:53:01.547888Z",
+     "shell.execute_reply": "2024-06-21T22:53:01.547621Z"
     }
    },
    "outputs": [],
@@ -199,6 +200,7 @@
     "class CustomDataCallbacks(EpisodeDataCallbacks):\n",
     "    def pull_env_metrics(self, env):\n",
     "        reward = env.rewarder.cum_reward\n",
+    "        reward = sum(reward.values()) / len(reward)\n",
     "        orbits = env.simulator.sim_time / (95 * 60)\n",
     "\n",
     "        data = dict(\n",
@@ -229,10 +231,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T20:59:48.792806Z",
-     "iopub.status.busy": "2024-05-31T20:59:48.792588Z",
-     "iopub.status.idle": "2024-05-31T20:59:48.795422Z",
-     "shell.execute_reply": "2024-05-31T20:59:48.795192Z"
+     "iopub.execute_input": "2024-06-21T22:53:01.549749Z",
+     "iopub.status.busy": "2024-06-21T22:53:01.549535Z",
+     "iopub.status.idle": "2024-06-21T22:53:01.552345Z",
+     "shell.execute_reply": "2024-06-21T22:53:01.552119Z"
     }
    },
    "outputs": [],
@@ -244,7 +246,7 @@
     "training_args = dict(\n",
     "    lr=0.00003,\n",
     "    gamma=0.999,\n",
-    "    train_batch_size=5000,\n",
+    "    train_batch_size=250,  # In practice, usually a bigger number\n",
     "    num_sgd_iter=10,\n",
     "    model=dict(fcnet_hiddens=[512, 512], vf_share_layers=False),\n",
     "    lambda_=0.95,\n",
@@ -256,14 +258,14 @@
     "config = (\n",
     "    PPOConfig()\n",
     "    .training(**training_args)\n",
-    "    .env_runners(num_env_runners=7, sample_timeout_s=1000.0)\n",
+    "    .env_runners(num_env_runners=2, sample_timeout_s=1000.0)\n",
     "    .environment(\n",
     "        env=unpack_config(SatelliteTasking),\n",
     "        env_config=env_args,\n",
     "    )\n",
     "    .callbacks(CustomDataCallbacks)\n",
     "    .reporting(\n",
-    "        metrics_num_episodes_for_smoothing=25,\n",
+    "        metrics_num_episodes_for_smoothing=1,\n",
     "        metrics_episode_collection_timeout_s=180,\n",
     "    )\n",
     "    .checkpointing(export_native_model_files=True)\n",
@@ -278,27 +280,268 @@
     "Once the PPO configuration has been set, `ray` can be started and the agent can be\n",
     "trained.\n",
     "\n",
-    "```python\n",
+    "Training on a reasonably modern machine, we can achieve 5M steps over 32 processors in 6\n",
+    "to 18 hours, depending on specific environment configurations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-21T22:53:01.553687Z",
+     "iopub.status.busy": "2024-06-21T22:53:01.553598Z",
+     "iopub.status.idle": "2024-06-21T22:53:32.724754Z",
+     "shell.execute_reply": "2024-06-21T22:53:32.723824Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,117\tINFO worker.py:1749 -- Started a local Ray instance.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,441\tINFO tune.py:614 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/markstephenson/avslab/refactor/.venv_refactor/lib/python3.10/site-packages/gymnasium/spaces/box.py:130: UserWarning: \u001b[33mWARN: Box bound precision lowered by casting to float32\u001b[0m\n",
+      "  gym.logger.warn(f\"Box bound precision lowered by casting to {self.dtype}\")\n",
+      "/Users/markstephenson/avslab/refactor/.venv_refactor/lib/python3.10/site-packages/gymnasium/utils/passive_env_checker.py:164: UserWarning: \u001b[33mWARN: The obs returned by the `reset()` method was expecting numpy array dtype to be float32, actual type: float64\u001b[0m\n",
+      "  logger.warn(\n",
+      "/Users/markstephenson/avslab/refactor/.venv_refactor/lib/python3.10/site-packages/gymnasium/utils/passive_env_checker.py:188: UserWarning: \u001b[33mWARN: The obs returned by the `reset()` method is not within the observation space.\u001b[0m\n",
+      "  logger.warn(f\"{pre} is not within the observation space.\")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"tuneStatus\">\n",
+       "  <div style=\"display: flex;flex-direction: row\">\n",
+       "    <div style=\"display: flex;flex-direction: column;\">\n",
+       "      <h3>Tune Status</h3>\n",
+       "      <table>\n",
+       "<tbody>\n",
+       "<tr><td>Current time:</td><td>2024-06-21 15:53:31</td></tr>\n",
+       "<tr><td>Running for: </td><td>00:00:27.67        </td></tr>\n",
+       "<tr><td>Memory:      </td><td>13.5/16.0 GiB      </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n",
+       "    </div>\n",
+       "    <div class=\"vDivider\"></div>\n",
+       "    <div class=\"systemInfo\">\n",
+       "      <h3>System Info</h3>\n",
+       "      Using FIFO scheduling algorithm.<br>Logical resource usage: 3.0/3 CPUs, 0/0 GPUs\n",
+       "    </div>\n",
+       "    \n",
+       "  </div>\n",
+       "  <div class=\"hDivider\"></div>\n",
+       "  <div class=\"trialStatus\">\n",
+       "    <h3>Trial Status</h3>\n",
+       "    <table>\n",
+       "<thead>\n",
+       "<tr><th>Trial name                               </th><th>status    </th><th>loc            </th><th style=\"text-align: right;\">  iter</th><th style=\"text-align: right;\">  total time (s)</th><th style=\"text-align: right;\">  ts</th><th style=\"text-align: right;\">  num_healthy_workers</th><th style=\"text-align: right;\">  num_in_flight_async_\n",
+       "reqs</th><th style=\"text-align: right;\">  num_remote_worker_re\n",
+       "starts</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>PPO_SatelliteTasking_Unpacked_04380_00000</td><td>TERMINATED</td><td>127.0.0.1:70339</td><td style=\"text-align: right;\">    10</td><td style=\"text-align: right;\">          18.558</td><td style=\"text-align: right;\">2500</td><td style=\"text-align: right;\">                    2</td><td style=\"text-align: right;\">0</td><td style=\"text-align: right;\">0</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n",
+       "  </div>\n",
+       "</div>\n",
+       "<style>\n",
+       ".tuneStatus {\n",
+       "  color: var(--jp-ui-font-color1);\n",
+       "}\n",
+       ".tuneStatus .systemInfo {\n",
+       "  display: flex;\n",
+       "  flex-direction: column;\n",
+       "}\n",
+       ".tuneStatus td {\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       ".tuneStatus .trialStatus {\n",
+       "  display: flex;\n",
+       "  flex-direction: column;\n",
+       "}\n",
+       ".tuneStatus h3 {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       ".tuneStatus .hDivider {\n",
+       "  border-bottom-width: var(--jp-border-width);\n",
+       "  border-bottom-color: var(--jp-border-color0);\n",
+       "  border-bottom-style: solid;\n",
+       "}\n",
+       ".tuneStatus .vDivider {\n",
+       "  border-left-width: var(--jp-border-width);\n",
+       "  border-left-color: var(--jp-border-color0);\n",
+       "  border-left-style: solid;\n",
+       "  margin: 0.5em 1em 0.5em 1em;\n",
+       "}\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,474\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_cpus_per_worker` has been deprecated. Use `AlgorithmConfig.num_cpus_per_env_runner` instead. This will raise an error in the future!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,474\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_gpus_per_worker` has been deprecated. Use `AlgorithmConfig.num_gpus_per_env_runner` instead. This will raise an error in the future!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,474\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_learner_workers` has been deprecated. Use `AlgorithmConfig.num_learners` instead. This will raise an error in the future!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,474\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_cpus_per_learner_worker` has been deprecated. Use `AlgorithmConfig.num_cpus_per_learner` instead. This will raise an error in the future!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-21 15:53:03,474\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_gpus_per_learner_worker` has been deprecated. Use `AlgorithmConfig.num_gpus_per_learner` instead. This will raise an error in the future!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:07,538\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_cpus_per_worker` has been deprecated. Use `AlgorithmConfig.num_cpus_per_env_runner` instead. This will raise an error in the future!\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:07,538\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_gpus_per_worker` has been deprecated. Use `AlgorithmConfig.num_gpus_per_env_runner` instead. This will raise an error in the future!\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:07,538\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_learner_workers` has been deprecated. Use `AlgorithmConfig.num_learners` instead. This will raise an error in the future!\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:07,538\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_cpus_per_learner_worker` has been deprecated. Use `AlgorithmConfig.num_cpus_per_learner` instead. This will raise an error in the future!\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:07,538\tWARNING deprecation.py:50 -- DeprecationWarning: `AlgorithmConfig.num_gpus_per_learner_worker` has been deprecated. Use `AlgorithmConfig.num_gpus_per_learner` instead. This will raise an error in the future!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(PPO pid=70339)\u001b[0m Install gputil for GPU system monitoring.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:14,125\tWARNING deprecation.py:50 -- DeprecationWarning: `_get_slice_indices` has been deprecated. This will raise an error in the future!\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:14,143\tWARNING tf_utils.py:774 -- KL divergence is non-finite, this will likely destabilize your model and the training process. Action(s) in a specific state have near-zero probability. This can happen naturally in deterministic environments where the optimal policy has zero mass for a specific action. To fix this issue, consider setting the coefficient for the KL loss term to zero or increasing policy entropy.\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:14,270\tWARNING tf_utils.py:774 -- KL divergence is non-finite, this will likely destabilize your model and the training process. Action(s) in a specific state have near-zero probability. This can happen naturally in deterministic environments where the optimal policy has zero mass for a specific action. To fix this issue, consider setting the coefficient for the KL loss term to zero or increasing policy entropy.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(PPO pid=70339)\u001b[0m 2024-06-21 15:53:14,488\tWARNING tf_utils.py:774 -- KL divergence is non-finite, this will likely destabilize your model and the training process. Action(s) in a specific state have near-zero probability. This can happen naturally in deterministic environments where the optimal policy has zero mass for a specific action. To fix this issue, consider setting the coefficient for the KL loss term to zero or increasing policy entropy.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"trialProgress\">\n",
+       "  <h3>Trial Progress</h3>\n",
+       "  <table>\n",
+       "<thead>\n",
+       "<tr><th>Trial name                               </th><th style=\"text-align: right;\">  agent_timesteps_total</th><th>counters                                                                                                                        </th><th>custom_metrics  </th><th>env_runners                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 </th><th>episode_media  </th><th style=\"text-align: right;\">    fps</th><th>info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        </th><th style=\"text-align: right;\">  num_agent_steps_sampled</th><th style=\"text-align: right;\">  num_agent_steps_sampled_lifetime</th><th style=\"text-align: right;\">  num_agent_steps_trained</th><th style=\"text-align: right;\">  num_env_steps_sampled</th><th style=\"text-align: right;\">  num_env_steps_sampled_lifetime</th><th style=\"text-align: right;\">  num_env_steps_sampled_this_iter</th><th style=\"text-align: right;\">  num_env_steps_sampled_throughput_per_sec</th><th style=\"text-align: right;\">  num_env_steps_trained</th><th style=\"text-align: right;\">  num_env_steps_trained_this_iter</th><th style=\"text-align: right;\">  num_env_steps_trained_throughput_per_sec</th><th style=\"text-align: right;\">  num_healthy_workers</th><th style=\"text-align: right;\">  num_in_flight_async_reqs</th><th style=\"text-align: right;\">  num_remote_worker_restarts</th><th style=\"text-align: right;\">  num_steps_trained_this_iter</th><th>perf                                                 </th><th>timers                                                                                                                                                                                                                         </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>PPO_SatelliteTasking_Unpacked_04380_00000</td><td style=\"text-align: right;\">                   2500</td><td>{&#x27;num_env_steps_sampled&#x27;: 2500, &#x27;num_env_steps_trained&#x27;: 2500, &#x27;num_agent_steps_sampled&#x27;: 2500, &#x27;num_agent_steps_trained&#x27;: 2500}</td><td>{}              </td><td>{&#x27;episode_reward_max&#x27;: 0.5413157894736842, &#x27;episode_reward_min&#x27;: 0.40394736842105244, &#x27;episode_reward_mean&#x27;: 0.4726315789473683, &#x27;episode_len_mean&#x27;: 88.0, &#x27;episode_media&#x27;: {}, &#x27;episodes_this_iter&#x27;: 2, &#x27;episodes_timesteps_total&#x27;: 176, &#x27;policy_reward_min&#x27;: {}, &#x27;policy_reward_max&#x27;: {}, &#x27;policy_reward_mean&#x27;: {}, &#x27;custom_metrics&#x27;: {&#x27;reward_mean&#x27;: 0.4726315789473683, &#x27;reward_min&#x27;: 0.40394736842105244, &#x27;reward_max&#x27;: 0.5413157894736842, &#x27;reward_per_orbit_mean&#x27;: 0.23631578947368415, &#x27;reward_per_orbit_min&#x27;: 0.20197368421052622, &#x27;reward_per_orbit_max&#x27;: 0.2706578947368421, &#x27;alive_mean&#x27;: 1.0, &#x27;alive_min&#x27;: 1.0, &#x27;alive_max&#x27;: 1.0, &#x27;rw_status_valid_mean&#x27;: 1.0, &#x27;rw_status_valid_min&#x27;: 1.0, &#x27;rw_status_valid_max&#x27;: 1.0, &#x27;battery_status_valid_mean&#x27;: 1.0, &#x27;battery_status_valid_min&#x27;: 1.0, &#x27;battery_status_valid_max&#x27;: 1.0, &#x27;orbits_complete_mean&#x27;: 2.0, &#x27;orbits_complete_min&#x27;: 2.0, &#x27;orbits_complete_max&#x27;: 2.0}, &#x27;hist_stats&#x27;: {&#x27;episode_reward&#x27;: [0.40394736842105244, 0.5413157894736842], &#x27;episode_lengths&#x27;: [92, 84]}, &#x27;sampler_perf&#x27;: {&#x27;mean_raw_obs_processing_ms&#x27;: 3.101712889332089, &#x27;mean_inference_ms&#x27;: 0.6436502142585248, &#x27;mean_action_processing_ms&#x27;: 0.04842222261009552, &#x27;mean_env_wait_ms&#x27;: 9.618122324192647, &#x27;mean_env_render_ms&#x27;: 0.0}, &#x27;num_faulty_episodes&#x27;: 0, &#x27;connector_metrics&#x27;: {&#x27;ObsPreprocessorConnector_ms&#x27;: 0.0033617019653320312, &#x27;StateBufferConnector_ms&#x27;: 0.0021576881408691406, &#x27;ViewRequirementAgentConnector_ms&#x27;: 0.04621744155883789}, &#x27;num_episodes&#x27;: 2, &#x27;episode_return_max&#x27;: 0.5413157894736842, &#x27;episode_return_min&#x27;: 0.40394736842105244, &#x27;episode_return_mean&#x27;: 0.4726315789473683}</td><td>{}             </td><td style=\"text-align: right;\">140.849</td><td>{&#x27;learner&#x27;: {&#x27;default_policy&#x27;: {&#x27;learner_stats&#x27;: {&#x27;cur_kl_coeff&#x27;: 0.0003906250058207661, &#x27;cur_lr&#x27;: 2.9999999242136255e-05, &#x27;total_loss&#x27;: 0.002937226, &#x27;policy_loss&#x27;: -0.0055964356, &#x27;vf_loss&#x27;: 0.008533249, &#x27;vf_explained_var&#x27;: -0.010654608, &#x27;kl&#x27;: 0.0010568084, &#x27;entropy&#x27;: 1.2708192, &#x27;entropy_coeff&#x27;: 0.0}, &#x27;custom_metrics&#x27;: {}, &#x27;num_agent_steps_trained&#x27;: 125.0, &#x27;num_grad_updates_lifetime&#x27;: 190.5, &#x27;diff_num_grad_updates_vs_sampler_policy&#x27;: 9.5}}, &#x27;num_env_steps_sampled&#x27;: 2500, &#x27;num_env_steps_trained&#x27;: 2500, &#x27;num_agent_steps_sampled&#x27;: 2500, &#x27;num_agent_steps_trained&#x27;: 2500}</td><td style=\"text-align: right;\">                     2500</td><td style=\"text-align: right;\">                              2500</td><td style=\"text-align: right;\">                     2500</td><td style=\"text-align: right;\">                   2500</td><td style=\"text-align: right;\">                            2500</td><td style=\"text-align: right;\">                              250</td><td style=\"text-align: right;\">                                   141.002</td><td style=\"text-align: right;\">                   2500</td><td style=\"text-align: right;\">                              250</td><td style=\"text-align: right;\">                                   141.002</td><td style=\"text-align: right;\">                    2</td><td style=\"text-align: right;\">                         0</td><td style=\"text-align: right;\">                           0</td><td style=\"text-align: right;\">                          250</td><td>{&#x27;cpu_util_percent&#x27;: 23.15, &#x27;ram_util_percent&#x27;: 84.1}</td><td>{&#x27;training_iteration_time_ms&#x27;: 1853.609, &#x27;restore_workers_time_ms&#x27;: 0.008, &#x27;training_step_time_ms&#x27;: 1853.58, &#x27;sample_time_ms&#x27;: 1729.096, &#x27;learn_time_ms&#x27;: 120.671, &#x27;learn_throughput&#x27;: 2071.752, &#x27;synch_weights_time_ms&#x27;: 3.59}</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<style>\n",
+       ".trialProgress {\n",
+       "  display: flex;\n",
+       "  flex-direction: column;\n",
+       "  color: var(--jp-ui-font-color1);\n",
+       "}\n",
+       ".trialProgress h3 {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       ".trialProgress td {\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(PPO pid=70339)\u001b[0m WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.\n",
+      "2024-06-21 15:53:31,138\tINFO tune.py:1007 -- Wrote the latest version of all result files and experiment state to '/Users/markstephenson/ray_results/PPO_2024-06-21_15-53-03' in 0.0166s.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(PPO pid=70339)\u001b[0m /Users/markstephenson/avslab/refactor/.venv_refactor/lib/python3.10/site-packages/keras/src/initializers/__init__.py:144: UserWarning: The `keras.initializers.serialize()` API should only be used for objects of type `keras.initializers.Initializer`. Found an instance of type <class 'function'>, which may lead to improper serialization.\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m   warnings.warn(\n",
+      "\u001b[36m(PPO pid=70339)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/Users/markstephenson/ray_results/PPO_2024-06-21_15-53-03/PPO_SatelliteTasking_Unpacked_04380_00000_0_2024-06-21_15-53-03/checkpoint_000000)\n",
+      "2024-06-21 15:53:31,305\tINFO tune.py:1039 -- Total run time: 27.86 seconds (27.65 seconds for the tuning loop).\n"
+     ]
+    }
+   ],
+   "source": [
     "import ray\n",
+    "from ray import tune\n",
     "\n",
     "ray.init(\n",
     "    ignore_reinit_error=True,\n",
-    "    num_cpus=8,\n",
+    "    num_cpus=3,\n",
     "    object_store_memory=2_000_000_000,  # 2 GB\n",
     ")\n",
     "\n",
-    "ppo = PPO(config)\n",
+    "# Run the training\n",
+    "tune.run(\n",
+    "    \"PPO\",\n",
+    "    config=config.to_dict(),\n",
+    "    stop={\"training_iteration\": 10},  # Adjust the number of iterations as needed\n",
+    "    checkpoint_freq=10,\n",
+    "    checkpoint_at_end=True\n",
+    ")\n",
     "\n",
-    "# Train the policy as you see fit\n",
-    "for _ in range(10):\n",
-    "    ppo.train()\n",
-    "    ppo.checkpoint()\n",
-    "\n",
-    "ray.shutdown()\n",
-    "```\n",
-    "\n",
-    "Training on a reasonably modern machine, we can achieve 5M steps over 32 processors in 6\n",
-    "to 18 hours, depending on specific environment configurations."
+    "# Shutdown Ray\n",
+    "ray.shutdown()"
    ]
   },
   {
@@ -321,13 +564,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T20:59:48.796859Z",
-     "iopub.status.busy": "2024-05-31T20:59:48.796754Z",
-     "iopub.status.idle": "2024-05-31T20:59:50.570406Z",
-     "shell.execute_reply": "2024-05-31T20:59:50.569692Z"
+     "iopub.execute_input": "2024-06-21T22:53:32.730208Z",
+     "iopub.status.busy": "2024-06-21T22:53:32.729939Z",
+     "iopub.status.idle": "2024-06-21T22:53:33.833308Z",
+     "shell.execute_reply": "2024-06-21T22:53:33.832981Z"
     }
    },
    "outputs": [
@@ -335,7882 +578,5418 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,797 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mResetting environment with seed=443345856\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,734 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mResetting environment with seed=3627897200\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,888 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,830 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,930 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,855 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,931 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mEnvironment reset\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,856 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mEnvironment reset\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,932 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,856 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,932 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,856 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,932 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 180.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,857 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 60.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,933 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,857 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,943 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 180.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,861 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 60.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,943 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,861 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,944 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,862 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,944 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,862 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,945 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,862 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,945 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,862 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,945 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 360.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,863 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 120.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,945 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,863 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<60.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,956 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 360.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,867 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 120.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,956 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,867 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,957 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,868 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,957 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,868 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,957 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,868 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,958 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,868 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,958 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 540.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,868 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 180.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,958 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,869 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<120.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,968 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 540.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,872 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 180.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,968 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.007543859649122808}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,873 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,969 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,873 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,969 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mStep reward: 0.007543859649122808\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,874 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,969 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,874 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,970 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,874 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,970 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 600.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,874 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 360.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,970 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,875 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<180.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,974 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 600.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,885 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 360.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,974 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,885 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,975 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,886 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,975 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,886 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,975 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,886 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,976 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,886 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,976 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 780.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,886 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 540.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,976 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,887 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<360.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,986 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 780.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,897 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 540.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,986 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,897 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,987 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,897 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,987 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,898 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,987 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,898 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,988 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,898 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,988 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 840.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,898 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 600.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,988 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<780.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,899 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<540.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,992 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 840.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,902 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 600.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,992 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,903 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,993 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,903 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,993 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,904 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,994 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,904 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,994 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,904 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,994 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 900.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,904 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 660.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,994 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,904 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<600.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,998 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 900.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,908 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 660.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,998 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,908 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,999 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,909 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:48,999 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,909 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,000 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,910 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,000 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,910 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,000 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1080.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,910 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 840.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,000 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,910 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<660.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,011 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1080.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,920 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 840.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,011 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,920 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,012 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,921 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,012 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,921 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,012 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,922 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,013 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,922 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,013 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1260.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,922 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 900.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,013 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,922 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<840.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,023 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1260.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,926 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 900.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,024 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,926 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,025 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,927 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,025 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,927 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,025 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,927 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,025 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,928 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,026 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1320.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,928 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 960.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,026 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1260.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,928 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<900.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,030 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1320.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,932 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 960.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,030 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,932 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,031 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,933 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,031 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,933 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,031 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,933 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,032 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,934 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,032 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1380.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,934 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1020.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,032 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1320.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,934 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<960.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,036 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1380.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,938 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1020.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,036 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,938 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,037 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,939 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,037 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,939 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,037 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,939 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,038 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,939 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,038 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1560.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,939 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1080.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,038 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,940 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1020.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,049 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1560.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,943 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1080.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,049 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,944 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,050 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,944 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,050 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,945 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,050 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,945 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,050 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,945 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,051 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1740.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,945 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1140.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,051 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,945 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1080.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,061 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1740.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,949 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1140.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,061 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,949 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,062 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,950 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,062 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,950 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,063 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,951 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,063 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,951 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,063 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1920.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,951 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1200.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,063 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,951 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1140.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,073 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1920.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,955 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1200.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,074 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,955 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,074 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,956 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,075 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,956 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,075 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,956 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,075 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,956 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,075 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1980.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,957 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1380.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,075 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1920.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,957 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1200.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,079 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1980.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,967 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1380.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,079 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,967 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.011666666666666665}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,080 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,968 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,080 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,968 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mStep reward: 0.011666666666666665\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,081 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,968 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,081 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,968 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,081 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2160.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,969 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1560.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,081 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,969 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1380.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,092 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2160.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,979 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1560.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,092 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,979 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,093 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,980 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,093 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,980 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,094 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,980 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,094 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,980 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,094 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2340.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,981 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1620.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,094 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,981 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1560.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,105 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2340.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,984 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1620.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,105 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,985 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,106 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,985 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,106 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,986 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,106 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,986 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,107 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,986 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,107 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2400.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,986 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1680.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,107 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,987 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1620.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,111 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2400.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,990 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1680.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,111 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,990 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,112 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,991 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,112 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,991 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,113 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,992 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,113 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,992 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,113 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2460.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,992 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1740.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,113 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2400.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,992 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1680.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,117 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2460.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,996 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1740.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,117 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,996 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,118 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,997 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,118 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,997 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,119 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,997 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,119 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,997 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,119 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2520.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,998 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1800.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,119 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2460.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:32,998 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1740.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,123 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2520.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,001 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1800.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,123 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,002 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,124 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,003 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,124 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,003 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,124 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,003 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,125 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,003 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,125 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2700.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,004 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 1980.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,125 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,004 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1800.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,136 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2700.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,014 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 1980.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,136 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,014 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.011842105263157893}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,137 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,015 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,137 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,015 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mStep reward: 0.011842105263157893\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,137 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,015 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,138 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,015 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,138 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2880.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,015 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2160.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,138 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2700.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,016 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<1980.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,149 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2880.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,026 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2160.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,149 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,026 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,150 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,027 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,150 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,027 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,151 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,027 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,151 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,027 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,151 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3060.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,028 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2340.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,152 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2880.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,028 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2160.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,162 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3060.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,038 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2340.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,163 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,038 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,164 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,039 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,164 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,039 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,164 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,039 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,165 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,040 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,165 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3120.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,040 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2520.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,165 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3060.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,040 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2340.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,169 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3120.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,050 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2520.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,169 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,050 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,170 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,051 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,170 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,051 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,171 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,051 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,171 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,052 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,171 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3300.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,052 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2580.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,171 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3120.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,052 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2520.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,182 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3300.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,056 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2580.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,182 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008187134502923977}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,056 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,183 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,057 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,183 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[mStep reward: 0.008187134502923977\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,057 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,184 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,057 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,184 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,057 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,184 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3360.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,057 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2760.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,185 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3300.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,058 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2580.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,188 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3360.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,068 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2760.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,189 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,068 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,190 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,069 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,190 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,069 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,190 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,069 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,191 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,069 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,191 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3420.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,070 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 2940.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,191 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3360.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,070 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2760.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,195 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3420.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,080 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 2940.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,195 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,080 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,196 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,081 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,196 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,081 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,197 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,081 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,197 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,081 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,197 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3480.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,082 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3000.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,197 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,082 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<2940.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,201 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3480.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,086 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3000.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,202 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,086 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,203 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,087 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,203 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,087 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,203 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,087 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,203 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,087 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,204 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3660.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,087 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3180.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,204 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,088 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3000.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,215 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3660.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,098 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3180.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,215 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,098 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.012543859649122807}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,216 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,099 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,216 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,099 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[mStep reward: 0.012543859649122807\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,216 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,099 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,217 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,099 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,217 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3840.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,100 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3240.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,217 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,100 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3180.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,227 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3840.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,103 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3240.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,228 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,104 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,228 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,104 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,229 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,105 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,229 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,105 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,229 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,105 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,230 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3900.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,105 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3420.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,230 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,106 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3240.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,234 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3900.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,116 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3420.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,234 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,116 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.012105263157894735}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,235 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,117 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,235 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,117 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mStep reward: 0.012105263157894735\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,236 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,117 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,236 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,117 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,236 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3960.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,117 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3480.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,236 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3900.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,118 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3420.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,240 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3960.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,121 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3480.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,241 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,122 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,241 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,122 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,242 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,122 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,242 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,123 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,242 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,123 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,242 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4140.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,123 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3660.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,243 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3960.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,123 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3480.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,253 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4140.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,133 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3660.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,254 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,133 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,254 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,134 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,255 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,134 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,255 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,135 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,255 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,135 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,255 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4320.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,135 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 3840.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,256 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4140.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,135 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3660.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,266 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4320.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,145 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 3840.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,266 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0076608187134502926}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,146 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,267 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,146 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,267 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mStep reward: 0.0076608187134502926\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,147 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,268 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,147 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,268 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,147 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,268 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4500.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,147 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4020.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,268 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,148 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<3840.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,279 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4500.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,158 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4020.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,279 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,158 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,280 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,159 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,280 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,159 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,281 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,159 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,281 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,159 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,281 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4680.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,159 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4080.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,281 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4500.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,160 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4020.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,292 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4680.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,163 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4080.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,292 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,164 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,293 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,164 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,293 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,165 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,293 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,165 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,294 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,165 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,294 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4740.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,165 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4260.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,294 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4680.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,166 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4080.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,298 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4740.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,176 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4260.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,298 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,176 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.012456140350877193}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,299 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,177 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,299 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,177 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[mStep reward: 0.012456140350877193\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,300 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,177 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,300 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,177 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,300 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4920.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,177 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4320.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,300 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4740.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,178 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4260.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,311 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4920.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,181 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4320.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,311 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,182 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,312 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,182 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,312 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,182 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,313 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,183 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,313 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,183 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,313 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4980.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,183 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4380.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,313 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,183 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4320.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,317 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4980.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,187 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4380.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,318 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,187 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,319 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,188 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,319 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,188 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,319 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,188 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,319 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,189 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,320 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5160.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,189 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4440.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,320 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,189 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4380.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,330 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5160.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,193 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4440.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,331 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,193 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,332 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,194 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,332 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,194 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,332 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,194 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,332 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,194 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,333 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5340.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,195 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4620.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,333 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,195 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4440.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,344 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5340.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,205 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4620.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,344 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0077192982456140355}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,205 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,345 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,206 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,345 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mStep reward: 0.0077192982456140355\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,206 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,345 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,206 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,346 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,206 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,346 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5520.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,207 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4800.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,346 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,207 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4620.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,356 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5520.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,217 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4800.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,357 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,217 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,358 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,218 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,358 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,218 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,358 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,218 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,358 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,218 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,359 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5580.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,219 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4860.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,359 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,219 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4800.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,363 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5580.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,222 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4860.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,363 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,223 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,364 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,223 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,364 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,224 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,364 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,224 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,365 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,224 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,365 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5640.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,224 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4920.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,365 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5580.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,224 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4860.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,369 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5640.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,228 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4920.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,369 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,228 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,370 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,229 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,371 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,229 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,371 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,230 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,371 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,230 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,371 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5820.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,230 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 4980.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,372 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5640.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,230 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4920.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,382 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5820.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,234 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 4980.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,382 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,234 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,383 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,235 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,383 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,235 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,384 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,236 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,384 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,236 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,384 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6000.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,236 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5160.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,384 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,236 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<4980.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,395 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6000.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,246 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5160.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,395 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,246 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,397 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,247 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,397 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,247 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,397 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,248 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,398 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,248 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,398 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6180.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,248 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5340.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,398 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,248 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5160.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,408 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6180.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,258 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5340.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,409 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008128654970760233}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,258 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,410 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,259 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,410 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mStep reward: 0.008128654970760233\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,259 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,410 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,260 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,410 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,260 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,411 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6240.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,260 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5520.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,411 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,260 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5340.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,415 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6240.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,270 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5520.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,415 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,270 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,416 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,271 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,416 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,271 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,416 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,271 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,417 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,272 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,417 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6300.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,272 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5700.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,417 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,272 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5520.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,421 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6300.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,282 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5700.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,421 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,282 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.013684210526315788}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,422 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,283 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,422 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,283 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[mStep reward: 0.013684210526315788\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,423 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,283 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,423 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,284 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,423 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6360.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,284 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5760.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,423 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6300.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,284 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5700.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,427 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6360.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,288 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5760.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,427 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,288 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,428 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,289 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,428 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,289 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,429 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,289 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,429 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,289 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,429 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6420.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,290 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 5820.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,429 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6360.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,290 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5760.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,433 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6420.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,293 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 5820.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,433 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,294 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,434 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,294 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,435 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,295 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,435 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,295 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,435 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,295 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,435 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6600.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,295 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6000.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,436 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,296 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<5820.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,446 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6600.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,305 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6000.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,447 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,306 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,448 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,306 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,448 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,307 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,448 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,307 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,448 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,307 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,449 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6660.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,307 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6180.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,449 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,307 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6000.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,453 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6660.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,317 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6180.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,453 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,318 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,454 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,318 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,454 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,318 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,454 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,319 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,455 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,319 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,455 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6720.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,319 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6240.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,455 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,319 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6180.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,459 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6720.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,323 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6240.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,459 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,323 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,460 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,324 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,460 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,324 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,461 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,324 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,461 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,325 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,461 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6900.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,325 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6420.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,461 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6720.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,325 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6240.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,472 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6900.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,335 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6420.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,472 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,335 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.01219298245614035}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,473 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,336 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,474 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,336 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mStep reward: 0.01219298245614035\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,474 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,337 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,474 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,337 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,474 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7080.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,337 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6600.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,475 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6900.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,337 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6420.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,485 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7080.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,347 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6600.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,485 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,347 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,486 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,348 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,486 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,348 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,487 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,348 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,487 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,349 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,487 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7260.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,349 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6660.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,487 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,349 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6600.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,498 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7260.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,353 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6660.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,498 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,353 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,499 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,354 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,499 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,354 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,500 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,354 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,500 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,354 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,500 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7320.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,355 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 6840.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,500 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,355 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6660.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,504 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7320.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,365 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 6840.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,505 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,365 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.01219298245614035}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,506 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,366 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,506 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,366 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[mStep reward: 0.01219298245614035\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,506 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,366 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,507 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,366 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,507 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7380.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,367 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7020.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,507 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,367 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<6840.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,511 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7380.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,377 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7020.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,511 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,377 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,512 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,378 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,513 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,378 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,513 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,378 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,513 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,378 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,514 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7560.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,379 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7080.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,514 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,379 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7020.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,525 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7560.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,382 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7080.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,525 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,383 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,526 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,383 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,526 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,384 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,526 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,384 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,527 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,384 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,527 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7740.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,384 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7260.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,527 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7560.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,384 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7080.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,538 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7740.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,394 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7260.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,538 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,395 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,539 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,395 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,539 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,396 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,540 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,396 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,540 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,396 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,540 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7920.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,396 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7320.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,540 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7740.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,396 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7260.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,551 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7920.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,400 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7320.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,551 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,400 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,552 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,401 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,552 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,401 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,553 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,401 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,553 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,402 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,553 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8100.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,402 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7380.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,553 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,402 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7320.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,564 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8100.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,406 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7380.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,564 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,406 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,565 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,407 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,565 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,407 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,566 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,407 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,566 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,407 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,566 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8280.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,408 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7440.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,566 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,408 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7380.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,577 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8280.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,411 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7440.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,577 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,412 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,578 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,412 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,578 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,413 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,579 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,413 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,579 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,413 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,579 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8340.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,413 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7500.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,580 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,413 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7440.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,583 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8340.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,417 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7500.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,584 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,417 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,585 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,418 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,585 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,418 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,585 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,419 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,586 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,419 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,586 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8520.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,419 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7680.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,586 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,419 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7500.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,596 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8520.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,429 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7680.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,597 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008128654970760233}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,429 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,598 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,430 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,598 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mStep reward: 0.008128654970760233\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,430 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,598 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,431 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,598 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,431 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,599 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8700.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,431 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7860.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,599 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,431 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7680.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,609 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8700.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,441 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7860.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,610 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,441 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,611 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,442 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,611 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,442 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,612 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,443 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,612 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,443 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,612 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8880.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,443 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 7920.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,612 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,443 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7860.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,622 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8880.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,447 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 7920.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,623 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,447 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,623 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,448 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,624 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,448 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,624 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,448 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,624 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,449 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,625 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8940.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,449 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8100.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,625 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8880.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,449 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<7920.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,629 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8940.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,459 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8100.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,629 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,460 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.012280701754385963}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,630 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,501 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,630 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,501 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mStep reward: 0.012280701754385963\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,631 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,502 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,631 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,502 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,631 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9000.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,502 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8280.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,631 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,502 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8100.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,635 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9000.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,512 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8280.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,636 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,513 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,636 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,513 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,637 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,513 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,637 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,514 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,637 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,514 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,637 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9180.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,514 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8340.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,638 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9000.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,514 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8280.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,648 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9180.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,518 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8340.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,649 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,518 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,650 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,519 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,650 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,519 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,650 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,519 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,650 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,520 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,651 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9240.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,520 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8520.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,651 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,520 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8340.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,655 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9240.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,530 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8520.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,655 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,530 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,656 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,531 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,656 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,531 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,657 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,531 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,657 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,532 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,657 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9300.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,532 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8580.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,657 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,532 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8520.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,661 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9300.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,536 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8580.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,661 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,536 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,662 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,537 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,662 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,537 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,663 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,537 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,663 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,538 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,663 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9360.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,538 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8640.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,663 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,538 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8580.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,667 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9360.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,573 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8640.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,668 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,573 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,668 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,574 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,669 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,574 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,669 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,575 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,669 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,575 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,669 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9540.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,575 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8700.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,670 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9360.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,575 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8640.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,680 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9540.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,579 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8700.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,681 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,579 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,682 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,580 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,682 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,580 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,682 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,580 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,683 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,581 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,683 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9720.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,581 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8760.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,683 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9540.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,581 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8700.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,693 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9720.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,585 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8760.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,694 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,585 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,695 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,586 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,695 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,586 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,696 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,586 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,696 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,586 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,696 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9780.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,586 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 8940.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,696 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9720.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,587 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8760.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,700 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9780.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,596 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 8940.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,701 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,597 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,701 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,597 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,702 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,598 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,702 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,598 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,702 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,598 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,702 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9960.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,598 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9120.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,703 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9780.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,598 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<8940.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,753 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9960.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,608 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9120.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,753 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,609 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,754 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,609 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,754 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,610 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,755 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,610 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,755 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,610 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,755 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10020.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,610 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9180.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,755 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9960.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,611 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9120.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,759 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10020.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,614 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9180.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,760 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,614 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,761 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,615 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,761 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,615 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,761 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,616 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,762 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,616 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,762 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10200.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,616 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9240.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,762 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,616 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9180.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,773 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10200.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,620 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9240.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,773 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008128654970760233}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,620 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,774 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,621 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,774 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mStep reward: 0.008128654970760233\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,621 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,775 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,621 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,775 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,621 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,775 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10260.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,622 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9300.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,776 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,622 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9240.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,780 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10260.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,625 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9300.0 for action_downlink\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,780 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,626 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,781 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,626 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,781 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,626 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,782 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,627 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,782 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,627 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,782 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10320.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,627 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9480.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,782 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10260.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,627 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9300.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,786 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10320.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,637 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9480.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,786 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,637 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,787 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,638 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,788 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,638 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,788 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,639 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,788 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,639 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,789 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10380.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,639 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9660.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,789 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10320.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,639 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9480.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,793 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10380.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,649 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9660.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,793 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,649 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,794 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,650 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,794 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,650 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,795 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,651 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,795 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,651 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,795 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10440.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,651 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 9840.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,796 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,651 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9660.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,800 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10440.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,661 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 9840.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,800 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,661 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,801 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,662 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,801 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,662 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,801 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,663 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,802 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,663 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,802 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10620.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,663 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10020.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,802 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10440.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,663 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<9840.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,813 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10620.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,673 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10020.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,814 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,673 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,814 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,674 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,815 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,674 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,815 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,674 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,815 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,675 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,816 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10800.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,675 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10080.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,816 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,675 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10020.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,826 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10800.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,679 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10080.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,827 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.007485380116959065}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,679 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,828 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,680 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,828 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[mStep reward: 0.007485380116959065\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,680 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,828 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,680 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,829 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,680 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,829 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10980.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,680 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10140.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,829 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10800.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,681 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10080.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,840 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10980.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,684 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10140.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,840 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,685 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,841 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,685 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,842 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,685 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,842 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,686 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,842 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,686 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,842 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11160.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,686 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10200.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,843 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10980.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,686 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10140.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,853 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11160.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,690 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10200.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,854 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,690 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,855 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,691 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,855 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,691 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,855 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,691 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,856 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,691 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,856 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11220.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,692 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10380.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,856 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11160.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,692 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10200.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,860 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11220.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,702 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10380.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,860 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,702 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,861 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,748 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,861 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,748 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,862 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,749 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,862 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,749 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,862 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11280.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,749 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10560.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,863 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,749 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10380.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,866 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11280.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,759 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10560.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,867 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,760 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,868 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,760 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,868 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,761 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,869 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,761 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,869 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,761 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,869 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11340.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,761 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10620.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,869 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11280.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,761 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10560.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,873 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11340.0 for action_downlink\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,765 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10620.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,874 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,765 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,874 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,766 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,875 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,766 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,875 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,766 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,876 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,767 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,876 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11520.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,767 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10680.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,876 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11340.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,767 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10620.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,887 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11520.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,771 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10680.0 for action_desat\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,887 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008187134502923977}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,771 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,888 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,772 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,889 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[mStep reward: 0.008187134502923977\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,772 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,889 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,772 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,889 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,773 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,890 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11580.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,773 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 10860.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,890 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11520.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,773 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10680.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,894 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11580.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,783 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 10860.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,894 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,784 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.012368421052631579}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,895 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,784 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,895 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,785 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[mStep reward: 0.012368421052631579\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,896 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,785 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,896 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,785 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,896 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11760.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,785 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11040.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,896 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11580.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,786 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<10860.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,907 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11760.0 for action_charge\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,796 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11040.0 for action_charge\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,908 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,796 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,909 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,796 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mFinding opportunity windows from 11400.00 to 12000.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,909 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,801 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mFinding opportunity windows from 12000.00 to 12600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,909 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,806 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,909 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,806 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,910 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11820.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,807 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,910 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11760.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,807 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,914 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11820.0 for action_desat\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,807 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11220.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,914 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,807 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11040.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,985 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,818 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 11220.0 for action_nadir_scan\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,986 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,818 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.013421052631578946}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,987 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,819 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4913732896']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,987 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,819 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mStep reward: 0.013421052631578946\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,988 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12000.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,819 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:49,988 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11820.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,820 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,000 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12000.0 for action_nadir_scan\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,820 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 11400.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,001 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,820 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11220.00> \u001b[0m\u001b[mRunning simulation at most to 11400.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,003 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,830 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11400.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4913732896': 0.015789473684210527}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,003 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,831 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11400.00> \u001b[0m\u001b[mStep reward: 0.015789473684210527\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,004 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,831 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11400.00> \u001b[0m\u001b[mEpisode terminated: True\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,005 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,005 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12060.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,005 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12000.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,010 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12060.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,011 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,012 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,013 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,013 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,013 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,014 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12120.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,014 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12060.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,019 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12120.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,019 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,021 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,021 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,022 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,023 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,023 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12180.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,023 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12120.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,028 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12180.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,029 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,030 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,030 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,031 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,031 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,032 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12240.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,032 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12180.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,036 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12240.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,037 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,038 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,038 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,038 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,039 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,039 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12420.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,039 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12240.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,052 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12420.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,053 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,054 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,054 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,055 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,055 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,056 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12600.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,056 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12420.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,067 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12600.0 for action_charge\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,068 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,069 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,069 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,070 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,070 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,070 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12660.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,071 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12600.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,075 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12660.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,075 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,076 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,077 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,077 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,077 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,078 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12720.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,078 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12660.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,082 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12720.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,083 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,084 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,084 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,084 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,085 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,085 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12780.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,085 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12720.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,089 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12780.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,089 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,090 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,091 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,091 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,092 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,092 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 12960.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,092 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12780.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,103 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 12960.0 for action_charge\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,104 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,105 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,105 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,106 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,106 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,106 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13140.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,107 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<12960.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,117 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13140.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,118 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.009473684210526316}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,119 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,119 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[mStep reward: 0.009473684210526316\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,120 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,120 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,120 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13200.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,121 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13140.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,125 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13200.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,126 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,126 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,127 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,127 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,127 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,128 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13260.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,128 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13200.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,133 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13260.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,133 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,134 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,135 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,135 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,135 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,136 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13320.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,136 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13260.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,140 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13320.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,141 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,142 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,142 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,142 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,143 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,143 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13500.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,143 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13320.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,154 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13500.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,155 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,156 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,156 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,156 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,157 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,157 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13680.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,157 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13500.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,168 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13680.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,168 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,169 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,170 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,170 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,171 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,171 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13740.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,172 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13680.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,175 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13740.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,175 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,176 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,176 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,177 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,177 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,177 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13920.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,178 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13740.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,189 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13920.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,189 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008128654970760233}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,190 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,191 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[mStep reward: 0.008128654970760233\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,191 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,191 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,192 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 13980.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,192 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13920.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,196 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 13980.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,197 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,198 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,198 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,198 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,198 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,199 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14040.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,199 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<13980.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,203 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14040.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,203 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,204 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,205 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,205 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,205 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,206 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14100.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,206 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14040.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,210 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14100.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,210 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,211 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,212 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,212 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,212 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,213 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14280.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,213 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14100.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,224 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14280.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,225 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,226 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,226 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,226 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,227 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,227 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14460.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,227 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14280.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,238 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14460.0 for action_charge\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,239 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,239 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,240 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,240 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,269 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,270 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14520.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,270 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14460.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,274 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14520.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,275 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,276 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,276 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,276 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,277 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,277 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14580.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,277 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14520.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,282 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14580.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,282 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,283 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,283 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,284 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,284 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,284 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14760.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,284 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14580.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,295 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14760.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,296 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,296 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,297 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,297 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,297 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,298 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14820.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,298 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14760.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,302 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14820.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,302 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,303 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,304 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,304 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,304 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,305 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 14880.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,305 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14820.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,309 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 14880.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,309 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,311 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,311 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,311 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,312 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,312 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15060.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,312 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<14880.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,323 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15060.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,324 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.00824561403508772}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,324 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,325 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[mStep reward: 0.00824561403508772\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,325 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,325 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,326 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15240.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,326 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15060.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,337 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15240.0 for action_charge\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,337 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,338 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,338 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,339 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,339 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,339 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15420.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,340 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15240.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,351 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15420.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,351 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008070175438596491}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,412 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,413 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[mStep reward: 0.008070175438596491\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,414 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,414 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,414 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15480.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,415 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15420.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,419 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15480.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,419 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,420 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,420 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,421 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,421 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,421 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15540.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,421 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15480.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,425 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15540.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,425 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,426 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,426 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,427 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,427 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,427 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15720.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,428 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15540.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,438 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15720.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,438 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008187134502923977}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,439 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mFinding opportunity windows from 17400.00 to 18000.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,445 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mFinding opportunity windows from 18000.00 to 18600.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,453 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,453 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[mStep reward: 0.008187134502923977\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,453 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,454 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,454 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 15900.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,454 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15720.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,465 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 15900.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,466 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,466 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,467 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,467 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,467 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,468 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16080.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,468 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<15900.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,478 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16080.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,478 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,479 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,480 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,480 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,480 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,481 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16260.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,481 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16080.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,492 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16260.0 for action_charge\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,492 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,493 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,493 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,494 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,494 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,494 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16320.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,495 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16260.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,499 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16320.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,499 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,500 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,500 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,501 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,501 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,501 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16500.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,502 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16320.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,513 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16500.0 for action_charge\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,513 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,514 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,514 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,515 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,515 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_desat tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,515 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16560.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,516 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16500.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,520 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16560.0 for action_desat\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,520 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,521 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,521 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,522 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,522 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_downlink tasked for 60.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,522 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16620.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,522 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16560.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,526 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16620.0 for action_downlink\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,527 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,527 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,528 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,528 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,528 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,528 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16800.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,529 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16620.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,539 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16800.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,540 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.008187134502923977}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,541 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,541 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[mStep reward: 0.008187134502923977\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,542 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,542 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_nadir_scan tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,542 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 16980.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,542 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16800.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,554 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[mtimed termination at 16980.0 for action_nadir_scan\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,555 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.010526315789473684}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,556 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[mSatellites requiring retasking: ['Scanner-1_4827225424']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,556 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[mStep reward: 0.010526315789473684\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,557 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,557 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[maction_charge tasked for 180.0 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,557 \u001b[0m\u001b[36msats.satellite.Scanner-1       \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[36mScanner-1: \u001b[0m\u001b[msetting timed terminal event at 17160.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,558 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<16980.00> \u001b[0m\u001b[mRunning simulation at most to 17100.00 seconds\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,566 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<17100.00> \u001b[0m\u001b[mData reward: {'Scanner-1_4827225424': 0.0}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,567 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<17100.00> \u001b[0m\u001b[mStep reward: 0.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,567 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<17100.00> \u001b[0m\u001b[mEpisode terminated: True\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 13:59:50,567 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<17100.00> \u001b[0m\u001b[mEpisode truncated: True\u001b[0m\n"
+      "\u001b[90;3m2024-06-21 15:53:33,831 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<11400.00> \u001b[0m\u001b[mEpisode truncated: True\u001b[0m\n"
      ]
     }
    ],
@@ -8226,7 +6005,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv_refactor",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -8244,5 +6023,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/rllib_training.ipynb
+++ b/examples/rllib_training.ipynb
@@ -72,6 +72,7 @@
     "            type=\"ground_station\",\n",
     "            n_ahead_observe=1,\n",
     "        ),\n",
+    "        obs.Time(),\n",
     "    ]\n",
     "    action_spec = [\n",
     "        act.Scan(duration=180.0),\n",
@@ -138,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "duration = 3 * 5700.0\n",
+    "duration = 2 * 5700.0  # About 2 orbits\n",
     "env_args = dict(\n",
     "    satellite=sat,\n",
     "    scenario=scene.UniformNadirScanning(value_per_second=1/duration),\n",
@@ -171,6 +172,7 @@
     "class CustomDataCallbacks(EpisodeDataCallbacks):\n",
     "    def pull_env_metrics(self, env):\n",
     "        reward = env.rewarder.cum_reward\n",
+    "        reward = sum(reward.values()) / len(reward)\n",
     "        orbits = env.simulator.sim_time / (95 * 60)\n",
     "\n",
     "        data = dict(\n",
@@ -209,7 +211,7 @@
     "training_args = dict(\n",
     "    lr=0.00003,\n",
     "    gamma=0.999,\n",
-    "    train_batch_size=5000,\n",
+    "    train_batch_size=250,  # In practice, usually a bigger number\n",
     "    num_sgd_iter=10,\n",
     "    model=dict(fcnet_hiddens=[512, 512], vf_share_layers=False),\n",
     "    lambda_=0.95,\n",
@@ -221,14 +223,14 @@
     "config = (\n",
     "    PPOConfig()\n",
     "    .training(**training_args)\n",
-    "    .env_runners(num_env_runners=7, sample_timeout_s=1000.0)\n",
+    "    .env_runners(num_env_runners=2, sample_timeout_s=1000.0)\n",
     "    .environment(\n",
     "        env=unpack_config(SatelliteTasking),\n",
     "        env_config=env_args,\n",
     "    )\n",
     "    .callbacks(CustomDataCallbacks)\n",
     "    .reporting(\n",
-    "        metrics_num_episodes_for_smoothing=25,\n",
+    "        metrics_num_episodes_for_smoothing=1,\n",
     "        metrics_episode_collection_timeout_s=180,\n",
     "    )\n",
     "    .checkpointing(export_native_model_files=True)\n",
@@ -243,27 +245,36 @@
     "Once the PPO configuration has been set, `ray` can be started and the agent can be\n",
     "trained.\n",
     "\n",
-    "```python\n",
+    "Training on a reasonably modern machine, we can achieve 5M steps over 32 processors in 6\n",
+    "to 18 hours, depending on specific environment configurations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ray\n",
+    "from ray import tune\n",
     "\n",
     "ray.init(\n",
     "    ignore_reinit_error=True,\n",
-    "    num_cpus=8,\n",
+    "    num_cpus=3,\n",
     "    object_store_memory=2_000_000_000,  # 2 GB\n",
     ")\n",
     "\n",
-    "ppo = PPO(config)\n",
+    "# Run the training\n",
+    "tune.run(\n",
+    "    \"PPO\",\n",
+    "    config=config.to_dict(),\n",
+    "    stop={\"training_iteration\": 10},  # Adjust the number of iterations as needed\n",
+    "    checkpoint_freq=10,\n",
+    "    checkpoint_at_end=True\n",
+    ")\n",
     "\n",
-    "# Train the policy as you see fit\n",
-    "for _ in range(10):\n",
-    "    ppo.train()\n",
-    "    ppo.checkpoint()\n",
-    "\n",
-    "ray.shutdown()\n",
-    "```\n",
-    "\n",
-    "Training on a reasonably modern machine, we can achieve 5M steps over 32 processors in 6\n",
-    "to 18 hours, depending on specific environment configurations."
+    "# Shutdown Ray\n",
+    "ray.shutdown()"
    ]
   },
   {
@@ -301,7 +312,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv_refactor",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -319,5 +330,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/bsk_rl/data/nadir_data.py
+++ b/src/bsk_rl/data/nadir_data.py
@@ -93,10 +93,13 @@ class ScanningTimeReward(GlobalReward):
                 is set to the time spent scanning times ``scenario.value_per_second``.
         """
         super().__init__()
-        if reward_fn is None:
-            reward_fn = lambda t: t * self.scenario.value_per_second
+        self._reward_fn = reward_fn
 
-        self.reward_fn = reward_fn
+    @property
+    def reward_fn(self):
+        if self._reward_fn is None:
+            return lambda t: t * self.scenario.value_per_second
+        return self._reward_fn
 
     def calculate_reward(
         self, new_data_dict: dict[str, "ScanningTime"]

--- a/src/bsk_rl/data/nadir_data.py
+++ b/src/bsk_rl/data/nadir_data.py
@@ -97,6 +97,10 @@ class ScanningTimeReward(GlobalReward):
 
     @property
     def reward_fn(self):
+        """Function to calculate reward based on time spent scanning nadir.
+
+        :meta private:
+        """
         if self._reward_fn is None:
             return lambda t: t * self.scenario.value_per_second
         return self._reward_fn


### PR DESCRIPTION
## ScanningTimeReward and scenario init order 

When using the rllib training example, the scenario is not added to the  ScanningTimeReward until GeneralSatelliteTasking calls link. Also added the ppo train call to the example notebook. The reward is also a dict not a float to take the average, which seem like what was intended, but dose not matter with one satellite. 

Closes #147

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

### How should this pull request be reviewed?
- [ ] By commit

## How Has This Been Tested?

Just running the example, with 

Please describe the tests that you ran to verify your changes.

### Passes Tests
Have not got the unit tests working in my env