### PR TITLE
Issue #150: Standardize multiagent info dict

### DIFF
--- a/docs/build/doctrees/nbsphinx/examples/multiagent_envs.ipynb
+++ b/docs/build/doctrees/nbsphinx/examples/multiagent_envs.ipynb
@@ -29,10 +29,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:48.425654Z",
-     "iopub.status.busy": "2024-05-31T23:24:48.425317Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.387782Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.387487Z"
+     "iopub.execute_input": "2024-06-19T21:41:01.743696Z",
+     "iopub.status.busy": "2024-06-19T21:41:01.743581Z",
+     "iopub.status.idle": "2024-06-19T21:41:02.724827Z",
+     "shell.execute_reply": "2024-06-19T21:41:02.724510Z"
     }
    },
    "outputs": [],
@@ -66,10 +66,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.389660Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.389501Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.391573Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.391353Z"
+     "iopub.execute_input": "2024-06-19T21:41:02.726643Z",
+     "iopub.status.busy": "2024-06-19T21:41:02.726502Z",
+     "iopub.status.idle": "2024-06-19T21:41:02.728646Z",
+     "shell.execute_reply": "2024-06-19T21:41:02.728414Z"
     }
    },
    "outputs": [],
@@ -108,10 +108,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.392927Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.392834Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.632571Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.632286Z"
+     "iopub.execute_input": "2024-06-19T21:41:02.729995Z",
+     "iopub.status.busy": "2024-06-19T21:41:02.729890Z",
+     "iopub.status.idle": "2024-06-19T21:41:02.977202Z",
+     "shell.execute_reply": "2024-06-19T21:41:02.976916Z"
     }
    },
    "outputs": [
@@ -119,49 +119,56 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,395 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mResetting environment with seed=3731917456\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,732 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mResetting environment with seed=3846705016\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,395 \u001b[0m\u001b[mscene.targets                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mGenerating 1000 targets\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,732 \u001b[0m\u001b[mscene.targets                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mGenerating 1000 targets\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,559 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,892 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,581 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,914 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,604 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,932 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,628 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_4594229376', 'EO-2_4594228272', 'EO-3_11383596672']\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,950 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,628 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mEnvironment reset\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,972 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_5000043568', 'EO-2_5000045248', 'EO-3_11856148224']\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[90;3m2024-06-19 14:41:02,973 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mEnvironment reset\u001b[0m\n"
      ]
     },
     {
@@ -199,10 +206,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.634093Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.633994Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.636359Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.636079Z"
+     "iopub.execute_input": "2024-06-19T21:41:02.978728Z",
+     "iopub.status.busy": "2024-06-19T21:41:02.978643Z",
+     "iopub.status.idle": "2024-06-19T21:41:02.980913Z",
+     "shell.execute_reply": "2024-06-19T21:41:02.980673Z"
     }
    },
    "outputs": [
@@ -234,10 +241,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.637912Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.637795Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.679079Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.678845Z"
+     "iopub.execute_input": "2024-06-19T21:41:02.982226Z",
+     "iopub.status.busy": "2024-06-19T21:41:02.982147Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.146825Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.146556Z"
     }
    },
    "outputs": [
@@ -245,126 +252,147 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,638 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,982 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,638 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,983 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,638 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-48) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,983 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-80) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,639 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-48) window enabled: 128.7 to 311.2\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,984 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-80) window enabled: 581.8 to 778.5\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,640 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 311.2\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,984 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 778.5\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,640 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,984 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,640 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-358) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,984 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-932) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,641 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-358) window enabled: 274.0 to 465.7\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,985 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-932) window enabled: 584.7 to 600.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,641 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 465.7\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,985 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 600.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,641 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 8 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,986 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 8 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,641 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-492) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,986 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-285) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,642 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-492) window enabled: 360.4 to 445.8\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,986 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-285) window enabled: 457.9 to 587.3\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,642 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 445.8\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,987 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 587.3\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,643 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mRunning simulation at most to 1000000000.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:02,987 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mRunning simulation at most to 1000000000.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,670 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mimaged Target(tgt-48)\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,076 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mimaged Target(tgt-285)\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,672 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[mData reward: {'EO-1_4594229376': 0.8490970043045871, 'EO-2_4594228272': 0.0, 'EO-3_11383596672': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,078 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[mData reward: {'EO-1_5000043568': 0.0, 'EO-2_5000045248': 0.0, 'EO-3_11856148224': 0.496731720382655}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,677 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_4594229376']\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,083 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,677 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[mStep reward: 0.8490970043045871\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,102 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 1200.00 to 1800.00 seconds\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[90;3m2024-06-19 14:41:03,124 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[90;3m2024-06-19 14:41:03,144 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-3_11856148224']\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[90;3m2024-06-19 14:41:03,145 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[mStep reward: 0.496731720382655\u001b[0m\n"
      ]
     }
    ],
@@ -377,28 +405,28 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.680564Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.680455Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.682667Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.682453Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.148433Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.148312Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.150609Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.150373Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(array([ 0.92952453, -0.02171651,  0.09485104, -0.01888697,  0.69626008,\n",
-       "        -0.01323879,  0.0592699 , -0.01956626,  0.31841486,  0.02726043,\n",
-       "         0.26016688,  0.03952533,  0.32174418,  0.04452711,  0.60532024,\n",
-       "         0.05192149,  0.64168396,  0.05674144,  0.59718288,  0.04868392]),\n",
-       " array([ 0.46677668, -0.02298246,  0.26183512, -0.00185962,  0.12937522,\n",
-       "        -0.00525075,  0.31902371,  0.00385037,  0.22778555,  0.00161488,\n",
-       "         0.94978415,  0.01525485,  0.83953352,  0.01127847,  0.54275875,\n",
-       "         0.02438937,  0.46276273,  0.02508408,  0.38153857,  0.02664706]),\n",
-       " array([ 0.52066306, -0.02298246,  0.95595429, -0.01953964,  0.90617328,\n",
-       "        -0.00112268,  0.78384523,  0.01969529,  0.13597152,  0.01157903,\n",
-       "         0.63195448,  0.0099964 ,  0.0967253 ,  0.04024514,  0.21411318,\n",
-       "         0.03755702,  0.6472315 ,  0.04509715,  0.77396428,  0.0801271 ]))"
+       "(array([ 0.5262301 , -0.03022015,  0.28402522, -0.03579063,  0.38350178,\n",
+       "        -0.03109852,  0.39765738,  0.02136911,  0.89579007, -0.00978359,\n",
+       "         0.40971075,  0.03062524,  0.60757276,  0.07549993,  0.82740313,\n",
+       "         0.06661879,  0.63714539,  0.05866202,  0.41172308,  0.05572379]),\n",
+       " array([0.27863449, 0.01223435, 0.29001943, 0.01815353, 0.52494685,\n",
+       "        0.02187046, 0.02328922, 0.07482971, 0.86722742, 0.12100024,\n",
+       "        0.08566248, 0.12243016, 0.75679172, 0.12717974, 0.26400625,\n",
+       "        0.15545994, 0.27951209, 0.14590077, 0.42070714, 0.1443381 ]),\n",
+       " array([ 0.05204218, -0.01767668,  0.46197972,  0.00982897,  0.39575618,\n",
+       "        -0.00939553,  0.24479972, -0.00428013,  0.83055036, -0.00454   ,\n",
+       "         0.34339089,  0.03947019,  0.78233513,  0.08417281,  0.67326847,\n",
+       "         0.08212403,  0.91057798,  0.12312927,  0.08304434,  0.11884015]))"
       ]
      },
      "execution_count": 6,
@@ -425,17 +453,17 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.684082Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.683977Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.685934Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.685717Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.152003Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.151907Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.153835Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.153590Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['EO-1_4594229376']"
+       "['EO-3_11856148224']"
       ]
      },
      "execution_count": 7,
@@ -459,17 +487,17 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.687262Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.687168Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.689261Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.689024Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.155135Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.155037Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.157208Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.156954Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[7, None, None]"
+       "[None, None, 7]"
       ]
      },
      "execution_count": 8,
@@ -488,10 +516,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.690566Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.690473Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.778479Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.778234Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.158497Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.158401Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.217410Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.217180Z"
     }
    },
    "outputs": [
@@ -499,84 +527,77 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,690 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,158 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,691 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,159 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,691 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-565) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,159 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-254) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,692 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-565) window enabled: 427.0 to 596.3\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,160 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-254) window enabled: 928.1 to 1117.9\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,692 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 596.3\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,160 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 1117.9\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,692 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<131.00> \u001b[0m\u001b[mRunning simulation at most to 1000000131.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,160 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<460.00> \u001b[0m\u001b[mRunning simulation at most to 1000000460.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,721 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mimaged Target(tgt-358)\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,184 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mimaged Target(tgt-80)\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,722 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[mData reward: {'EO-1_4594229376': 0.0, 'EO-2_4594228272': 0.46276272986490175, 'EO-3_11383596672': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,186 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[mData reward: {'EO-1_5000043568': 0.3976573836286119, 'EO-2_5000045248': 0.0, 'EO-3_11856148224': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,726 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,189 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 1200.00 to 1800.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,752 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,215 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_5000043568']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,776 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-2_4594228272']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,776 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[mStep reward: 0.46276272986490175\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,215 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[mStep reward: 0.3976573836286119\u001b[0m\n"
      ]
     }
    ],
@@ -597,10 +618,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.780055Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.779953Z",
-     "iopub.status.idle": "2024-05-31T23:24:49.849423Z",
-     "shell.execute_reply": "2024-05-31T23:24:49.849091Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.218946Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.218833Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.297171Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.296926Z"
     }
    },
    "outputs": [
@@ -608,154 +629,147 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,781 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,220 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,781 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 6 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,220 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 6 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,781 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-266) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,220 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-339) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,782 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-266) window enabled: 503.7 to 672.8\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,221 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-339) window enabled: 797.1 to 1005.4\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,782 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 672.8\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,221 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 1005.4\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,783 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,221 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,783 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-506) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,221 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-312) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,784 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-506) window enabled: 425.6 to 618.7\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,222 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-312) window enabled: 1346.1 to 1472.2\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,784 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 618.7\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,222 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 1472.2\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,784 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,222 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,784 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-739) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,223 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-774) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,785 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-739) window enabled: 453.6 to 600.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,223 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-774) window enabled: 1189.2 to 1200.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,785 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 600.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,223 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 1200.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,785 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<276.00> \u001b[0m\u001b[mRunning simulation at most to 1000000276.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,224 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<584.00> \u001b[0m\u001b[mRunning simulation at most to 1000000584.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,816 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mimaged Target(tgt-506)\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,265 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mimaged Target(tgt-339)\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,818 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[mData reward: {'EO-1_4594229376': 0.0, 'EO-2_4594228272': 0.539840444868018, 'EO-3_11383596672': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,267 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[mData reward: {'EO-1_5000043568': 0.7302026226885143, 'EO-2_5000045248': 0.0, 'EO-3_11856148224': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,822 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,271 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 1200.00 to 1800.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,846 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mfailed battery_valid check\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,294 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mfailed battery_valid check\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,847 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-2_4594228272']\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,295 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[mStep reward: -0.2697973773114857\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,847 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[mStep reward: -0.46015955513198203\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,295 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[mEpisode terminated: True\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,847 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[mEpisode terminated: True\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,847 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<428.00> \u001b[0m\u001b[mEpisode truncated: False\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,295 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<800.00> \u001b[0m\u001b[mEpisode truncated: False\u001b[0m\n"
      ]
     }
    ],
@@ -793,10 +807,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:49.851091Z",
-     "iopub.status.busy": "2024-05-31T23:24:49.851004Z",
-     "iopub.status.idle": "2024-05-31T23:24:50.305325Z",
-     "shell.execute_reply": "2024-05-31T23:24:50.305060Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.298733Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.298623Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.730489Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.730189Z"
     }
    },
    "outputs": [
@@ -804,71 +818,64 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:49,853 \u001b[0m\u001b[m                               \u001b[0m\u001b[93mWARNING    \u001b[0m\u001b[93mCreating logger for new env on PID=90763. Old environments in process may now log times incorrectly.\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,300 \u001b[0m\u001b[m                               \u001b[0m\u001b[93mWARNING    \u001b[0m\u001b[93mCreating logger for new env on PID=47859. Old environments in process may now log times incorrectly.\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,058 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mResetting environment with seed=100802160\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,504 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mResetting environment with seed=323861720\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,059 \u001b[0m\u001b[mscene.targets                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mGenerating 1000 targets\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,504 \u001b[0m\u001b[mscene.targets                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[mGenerating 1000 targets\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,214 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,659 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,235 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,685 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,256 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,708 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,280 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 0.00 to 600.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,726 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_5000044240', 'EO-2_11858113248', 'EO-3_11858112672']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,301 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_11385528784', 'EO-2_11385529888', 'EO-3_11385529456']\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,302 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mEnvironment reset\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,728 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mEnvironment reset\u001b[0m\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'EO-1_11385528784': Box(-1e+16, 1e+16, (20,), float64),\n",
-       " 'EO-2_11385529888': Box(-1e+16, 1e+16, (20,), float64),\n",
-       " 'EO-3_11385529456': Box(-1e+16, 1e+16, (20,), float64)}"
+       "{'EO-1_5000044240': Box(-1e+16, 1e+16, (20,), float64),\n",
+       " 'EO-2_11858113248': Box(-1e+16, 1e+16, (20,), float64),\n",
+       " 'EO-3_11858112672': Box(-1e+16, 1e+16, (20,), float64)}"
       ]
      },
      "execution_count": 11,
@@ -900,19 +907,19 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:50.306756Z",
-     "iopub.status.busy": "2024-05-31T23:24:50.306667Z",
-     "iopub.status.idle": "2024-05-31T23:24:50.308741Z",
-     "shell.execute_reply": "2024-05-31T23:24:50.308477Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.731850Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.731765Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.733767Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.733501Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'EO-1_11385528784': Discrete(10),\n",
-       " 'EO-2_11385529888': Discrete(10),\n",
-       " 'EO-3_11385529456': Discrete(10)}"
+       "{'EO-1_5000044240': Discrete(10),\n",
+       " 'EO-2_11858113248': Discrete(10),\n",
+       " 'EO-3_11858112672': Discrete(10)}"
       ]
      },
      "execution_count": 12,
@@ -937,10 +944,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:50.310153Z",
-     "iopub.status.busy": "2024-05-31T23:24:50.310075Z",
-     "iopub.status.idle": "2024-05-31T23:24:50.415334Z",
-     "shell.execute_reply": "2024-05-31T23:24:50.415115Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.735079Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.735007Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.823612Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.823328Z"
     }
    },
    "outputs": [
@@ -948,147 +955,147 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,311 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,736 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,312 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,736 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,312 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-225) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,737 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-576) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,313 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-225) window enabled: 549.0 to 711.2\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,737 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mTarget(tgt-576) window enabled: 244.2 to 457.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,313 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 711.2\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,738 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[msetting timed terminal event at 457.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,313 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,738 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,313 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-84) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,738 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-44) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,314 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-84) window enabled: 280.2 to 446.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,739 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-44) window enabled: 356.6 to 568.8\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,314 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 446.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,739 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 568.8\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,314 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 8 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,739 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 8 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,315 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-905) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,739 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-362) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,315 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-905) window enabled: 410.5 to 600.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,740 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-362) window enabled: 467.2 to 512.6\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,315 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 600.0\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,740 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 512.6\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,316 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mRunning simulation at most to 1000000000.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,740 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<0.00> \u001b[0m\u001b[mRunning simulation at most to 1000000000.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,373 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mimaged Target(tgt-84)\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,790 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mimaged Target(tgt-576)\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,375 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[mData reward: {'EO-1_11385528784': 0.0, 'EO-2_11385529888': 0.1736317989411481, 'EO-3_11385529456': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,792 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[mData reward: {'EO-1_5000044240': 0.09602657711509033, 'EO-2_11858113248': 0.0, 'EO-3_11858112672': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,382 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,797 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,412 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-2_11385529888']\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,820 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-1_5000044240']\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,413 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[mStep reward: {'EO-1_11385528784': 0.0, 'EO-2_11385529888': 0.1736317989411481, 'EO-3_11385529456': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,821 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[mStep reward: {'EO-1_5000044240': 0.09602657711509033, 'EO-2_11858113248': 0.0, 'EO-3_11858112672': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,413 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[mEpisode terminated: {'EO-1_11385528784': False, 'EO-2_11385529888': False, 'EO-3_11385529456': False}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,821 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[mEpisode terminated: {'EO-1_5000044240': False, 'EO-2_11858113248': False, 'EO-3_11858112672': False}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,413 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[mEpisode truncated: {'EO-1_11385528784': False, 'EO-2_11385529888': False, 'EO-3_11385529456': False}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,822 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[mEpisode truncated: {'EO-1_5000044240': False, 'EO-2_11858113248': False, 'EO-3_11858112672': False}\u001b[0m\n"
      ]
     }
    ],
@@ -1107,28 +1114,28 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:50.416817Z",
-     "iopub.status.busy": "2024-05-31T23:24:50.416737Z",
-     "iopub.status.idle": "2024-05-31T23:24:50.418835Z",
-     "shell.execute_reply": "2024-05-31T23:24:50.418560Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.825048Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.824965Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.827211Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.826962Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'EO-1_11385528784': array([ 0.60338287, -0.03011611,  0.87323203,  0.00419951,  0.80172144,\n",
-       "         0.00750755,  0.37153971,  0.04032373,  0.61646756,  0.04666259,\n",
-       "         0.48161493,  0.04785926,  0.47384484,  0.07925763,  0.0035083 ,\n",
-       "         0.07716695,  0.00291903,  0.08894771,  0.50867957,  0.12433105]),\n",
-       " 'EO-2_11385529888': array([ 0.63433108, -0.03101471,  0.23779057, -0.01630323,  0.58209618,\n",
-       "        -0.02437096,  0.50745344, -0.02125649,  0.96829724, -0.01826611,\n",
-       "         0.9566993 , -0.00644389,  0.59672177,  0.01027947,  0.36671403,\n",
-       "         0.03685701,  0.84354774,  0.01354962,  0.41031534,  0.04520229]),\n",
-       " 'EO-3_11385529456': array([ 0.18204768, -0.01113924,  0.29690295,  0.00256507,  0.76019462,\n",
-       "         0.02354056,  0.53067777,  0.03641876,  0.32337915,  0.04132224,\n",
-       "         0.27812719,  0.023271  ,  0.96258472,  0.02236515,  0.05312964,\n",
-       "         0.03625353,  0.99471926,  0.07202423,  0.80033185,  0.05908512])}"
+       "{'EO-1_5000044240': array([ 0.56920273, -0.02151521,  0.2297232 ,  0.00552812,  0.78461514,\n",
+       "        -0.01913435,  0.27567832,  0.00218598,  0.63697124,  0.01513787,\n",
+       "         0.39431237,  0.01633222,  0.49897218,  0.03226431,  0.10961557,\n",
+       "         0.01170529,  0.53807617,  0.05884056,  0.79886864,  0.02951799]),\n",
+       " 'EO-2_11858113248': array([ 0.44960104, -0.03470313,  0.30476257, -0.018098  ,  0.64042319,\n",
+       "         0.01451007,  0.89693457,  0.01316759,  0.10734452,  0.00934328,\n",
+       "         0.5349646 ,  0.0192207 ,  0.78408702,  0.0428556 ,  0.200825  ,\n",
+       "         0.05328849,  0.99644682,  0.03574838,  0.65767339,  0.06120948]),\n",
+       " 'EO-3_11858112672': array([ 0.5304967 , -0.03082372,  0.83496702, -0.00682569,  0.31186574,\n",
+       "        -0.00212665,  0.79837208,  0.00735195,  0.91402653,  0.03863149,\n",
+       "         0.13639769,  0.04140865,  0.17595261,  0.07536455,  0.51064093,\n",
+       "         0.06956332,  0.64879405,  0.06676183,  0.59261791,  0.07797086])}"
       ]
      },
      "execution_count": 14,
@@ -1153,17 +1160,17 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:50.420306Z",
-     "iopub.status.busy": "2024-05-31T23:24:50.420228Z",
-     "iopub.status.idle": "2024-05-31T23:24:50.422613Z",
-     "shell.execute_reply": "2024-05-31T23:24:50.422387Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.828539Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.828459Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.830698Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.830431Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['EO-2_11385529888', 'EO-3_11385529456']"
+       "['EO-2_11858113248', 'EO-3_11858112672']"
       ]
      },
      "execution_count": 15,
@@ -1182,10 +1189,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-05-31T23:24:50.423873Z",
-     "iopub.status.busy": "2024-05-31T23:24:50.423781Z",
-     "iopub.status.idle": "2024-05-31T23:24:50.508872Z",
-     "shell.execute_reply": "2024-05-31T23:24:50.508425Z"
+     "iopub.execute_input": "2024-06-19T21:41:03.831933Z",
+     "iopub.status.busy": "2024-06-19T21:41:03.831859Z",
+     "iopub.status.idle": "2024-06-19T21:41:03.911574Z",
+     "shell.execute_reply": "2024-06-19T21:41:03.911358Z"
     }
    },
    "outputs": [
@@ -1193,119 +1200,119 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,424 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,832 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[93;1m=== STARTING STEP ===\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,425 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,833 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[93mWARNING    \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[93mSatellite EO-1_5000044240 requires retasking but received no task.\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,425 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-420) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,833 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mtarget index 7 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,426 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-420) window enabled: 493.1 to 549.7\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,833 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-464) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,426 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 549.7\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,834 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mTarget(tgt-464) window enabled: 550.7 to 600.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,426 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,834 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[msetting timed terminal event at 600.0\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,427 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-405) tasked for imaging\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,835 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mtarget index 9 tasked\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,427 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-405) window enabled: 619.8 to 745.3\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,835 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-781) tasked for imaging\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,427 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 745.3\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,835 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[mTarget(tgt-781) window enabled: 691.4 to 904.3\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,428 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<283.00> \u001b[0m\u001b[mRunning simulation at most to 1000000283.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,835 \u001b[0m\u001b[34msats.satellite.EO-3            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[34mEO-3: \u001b[0m\u001b[msetting timed terminal event at 904.3\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,470 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mimaged Target(tgt-420)\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,836 \u001b[0m\u001b[msim.simulator                  \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<247.00> \u001b[0m\u001b[mRunning simulation at most to 1000000247.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,472 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[mData reward: {'EO-1_11385528784': 0.0, 'EO-2_11385529888': 0.3667140288589458, 'EO-3_11385529456': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,877 \u001b[0m\u001b[36msats.satellite.EO-1            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<457.00> \u001b[0m\u001b[36mEO-1: \u001b[0m\u001b[mtimed termination at 457.0 for Target(tgt-576) window\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,477 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,879 \u001b[0m\u001b[mdata.base                      \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<457.00> \u001b[0m\u001b[mData reward: {'EO-1_5000044240': 0.0, 'EO-2_11858113248': 0.0, 'EO-3_11858112672': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,505 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[mSatellites requiring retasking: ['EO-2_11385529888']\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,884 \u001b[0m\u001b[92msats.satellite.EO-2            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<457.00> \u001b[0m\u001b[92mEO-2: \u001b[0m\u001b[mFinding opportunity windows from 600.00 to 1200.00 seconds\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,506 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[mStep reward: {'EO-2_11385529888': 0.3667140288589458, 'EO-3_11385529456': 0.0}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,909 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<457.00> \u001b[0m\u001b[mStep reward: {'EO-2_11858113248': 0.0, 'EO-3_11858112672': 0.0}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,506 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[mEpisode terminated: {'EO-2_11385529888': False, 'EO-3_11385529456': False}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,910 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<457.00> \u001b[0m\u001b[mEpisode terminated: {'EO-2_11858113248': False, 'EO-3_11858112672': False}\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[90;3m2024-05-31 16:24:50,506 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<496.00> \u001b[0m\u001b[mEpisode truncated: {'EO-2_11385529888': False, 'EO-3_11385529456': False}\u001b[0m\n"
+      "\u001b[90;3m2024-06-19 14:41:03,910 \u001b[0m\u001b[mgym                            \u001b[0m\u001b[mINFO       \u001b[0m\u001b[33m<457.00> \u001b[0m\u001b[mEpisode truncated: {'EO-2_11858113248': False, 'EO-3_11858112672': False}\u001b[0m\n"
      ]
     }
    ],

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+Version 1.0.1
+-------------
+*Release Date: MMM. DD, YYYY*
+
+* Change the :class:`~bsk_rl.ConstellationTasking` environment info dictionary to include
+  all non-agent information in ``info['__common__']``, which is expected by RLlib's 
+  multiagent interfaces.
+
+
+
 Version 1.0.0
 -------------
 *Release Date: Jun. 12, 2024*

--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -567,6 +567,12 @@ class ConstellationTasking(
         for agent in self.possible_agents:
             if agent in self.previously_dead:
                 del info[agent]
+        for agent in self.agents:
+            info[agent] = {"events": info[agent]}
+        common = {k: v for k, v in info.items() if k not in self.possible_agents}
+        for k in common.keys():
+            del info[k]
+        info["__common__"] = common
         return info
 
     def step(

--- a/tests/unittest/test_gym_env.py
+++ b/tests/unittest/test_gym_env.py
@@ -376,7 +376,7 @@ class TestConstellationTasking:
         MagicMock(return_value=False),
     )
     def test_get_info(self):
-        mock_sats = [MagicMock(info={"sat_index": i}) for i in range(3)]
+        mock_sats = [MagicMock(info=[("sat_index", i)]) for i in range(3)]
         env = ConstellationTasking(
             satellites=mock_sats,
             world_type=MagicMock(),
@@ -385,9 +385,13 @@ class TestConstellationTasking:
         )
         env.newly_dead = []
         env.latest_step_duration = 10.0
-        expected = {sat.id: {"sat_index": i} for i, sat in enumerate(mock_sats)}
-        expected["d_ts"] = 10.0
-        expected["requires_retasking"] = [sat.id for sat in mock_sats]
+        expected = {
+            sat.id: {"events": [("sat_index", i)]} for i, sat in enumerate(mock_sats)
+        }
+        expected["__common__"] = {
+            "d_ts": 10.0,
+            "requires_retasking": [sat.id for sat in mock_sats],
+        }
         assert env._get_info() == expected
 
     def test_action_spaces(self):


### PR DESCRIPTION
## Description

RLlib's multiagency training expects a certain format for the PettingZoo info dict.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [X] __Documentation builds__ `cd docs; make html`

### Test Configuration
- Python:
- Basilisk:
- Platform: 

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I changed an example ipynb, I have locally rebuilt the documentation
