### PR TITLE
Standardize environment component resets and improve access satellite filtering

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,9 @@ Version 1.0.1
 * Change the :class:`~bsk_rl.ConstellationTasking` environment info dictionary to include
   all non-agent information in ``info['__common__']``, which is expected by RLlib's 
   multiagent interfaces.
-
+* Rewarder, communication, scenario, and satellites all have standardized ``reset_overwrite_previous``,
+  ``reset_pre_sim_init``, and ``reset_post_sim_init`` methods to all for more complex
+  initialization dependencies.
 
 
 Version 1.0.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,8 @@ Version 1.0.1
 * Rewarder, communication, scenario, and satellites all have standardized ``reset_overwrite_previous``,
   ``reset_pre_sim_init``, and ``reset_post_sim_init`` methods to all for more complex
   initialization dependencies.
+* Replace ``get_access_filter`` with :class:`~bsk_rl.sats.AccessSatellite.add_access_filter`,
+  which uses boolean functions to determine which opportunity windows to consider.
 
 
 Version 1.0.0

--- a/src/bsk_rl/comm/communication.py
+++ b/src/bsk_rl/comm/communication.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy.sparse.csgraph import connected_components
 
 from bsk_rl.sim.dyn import LOSCommDynModel
+from bsk_rl.utils.functional import Resetable
 
 if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.sats import Satellite
@@ -16,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class CommunicationMethod(ABC):
+class CommunicationMethod(ABC, Resetable):
     """Base class for defining data sharing between satellites."""
 
     def __init__(self) -> None:
@@ -34,10 +35,6 @@ class CommunicationMethod(ABC):
             satellites: List of satellites to communicate between.
         """
         self.satellites = satellites
-
-    def reset_post_sim_init(self) -> None:
-        """Reset communication after simulator initialization."""
-        pass
 
     @abstractmethod  # pragma: no cover
     def communication_pairs(self) -> list[tuple["Satellite", "Satellite"]]:

--- a/src/bsk_rl/data/base.py
+++ b/src/bsk_rl/data/base.py
@@ -4,6 +4,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from bsk_rl.utils.functional import Resetable
+
 if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.sats import Satellite
     from bsk_rl.scene import Scenario
@@ -112,7 +114,7 @@ class DataStore(ABC):
         self.staged_data = []
 
 
-class GlobalReward(ABC):
+class GlobalReward(ABC, Resetable):
     """Base class for simulation-wide data management."""
 
     datastore_type: type[DataStore]  # type of DataStore managed by the GlobalReward
@@ -134,8 +136,8 @@ class GlobalReward(ABC):
         """
         self.scenario = scenario
 
-    def reset_pre_sim_init(self) -> None:
-        """Refresh data and cumulative reward for a new episode prior to simulator construction."""
+    def reset_overwrite_previous(self) -> None:
+        """Overwrite attributes from previous episode."""
         self.data = self.data_type()
         self.cum_reward = {}
 

--- a/src/bsk_rl/data/unique_image_data.py
+++ b/src/bsk_rl/data/unique_image_data.py
@@ -142,7 +142,12 @@ class UniqueImageReward(GlobalReward):
     def create_data_store(self, satellite: "Satellite") -> None:
         """Override the access filter in addition to creating the data store."""
         super().create_data_store(satellite)
-        satellite.get_access_filter = lambda: satellite.data_store.data.imaged
+        if hasattr(satellite, "get_access_filter"):
+            satellite.get_access_filter = lambda: satellite.data_store.data.imaged
+        else:
+            logger.warning(
+                f"Satellite {satellite.name} does not have access filter for unique images."
+            )
 
     def calculate_reward(
         self, new_data_dict: dict[str, UniqueImageData]

--- a/src/bsk_rl/data/unique_image_data.py
+++ b/src/bsk_rl/data/unique_image_data.py
@@ -142,12 +142,13 @@ class UniqueImageReward(GlobalReward):
     def create_data_store(self, satellite: "Satellite") -> None:
         """Override the access filter in addition to creating the data store."""
         super().create_data_store(satellite)
-        if hasattr(satellite, "get_access_filter"):
-            satellite.get_access_filter = lambda: satellite.data_store.data.imaged
-        else:
-            logger.warning(
-                f"Satellite {satellite.name} does not have access filter for unique images."
-            )
+
+        def unique_target_filter(opportunity):
+            if opportunity["type"] == "target":
+                return opportunity["object"] not in satellite.data_store.data.imaged
+            return True
+
+        satellite.add_access_filter(unique_target_filter)
 
     def calculate_reward(
         self, new_data_dict: dict[str, UniqueImageData]

--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -104,6 +104,7 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
         self.world_args_generator = self.world_type.default_world_args(**world_args)
 
         self.scenario = scenario
+        self.scenario.link_satellites(self.satellites)
         self.rewarder = rewarder
         self.rewarder.link_scenario(self.scenario)
 
@@ -212,12 +213,19 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
         self.seed = seed
         super().reset(seed=self.seed)
         np.random.seed(self.seed)
-        self._generate_world_args()
 
+        self.scenario.reset_overwrite_previous()
+        self.rewarder.reset_overwrite_previous()
+        self.communicator.reset_overwrite_previous()
+        for satellite in self.satellites:
+            satellite.reset_overwrite_previous()
+
+        self._generate_world_args()
         self.latest_step_duration = 0.0
 
         self.scenario.reset_pre_sim_init()
         self.rewarder.reset_pre_sim_init()
+        self.communicator.reset_pre_sim_init()
 
         for satellite in self.satellites:
             self.rewarder.create_data_store(satellite)
@@ -233,6 +241,8 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
             time_limit=self.time_limit,
         )
 
+        self.scenario.reset_post_sim_init()
+        self.rewarder.reset_post_sim_init()
         self.communicator.reset_post_sim_init()
 
         for satellite in self.satellites:

--- a/src/bsk_rl/obs/observations.py
+++ b/src/bsk_rl/obs/observations.py
@@ -380,20 +380,6 @@ class OpportunityProperties(Observation):
 
         self.n_ahead_observe = int(n_ahead_observe)
 
-    def reset_post_sim_init(self) -> None:
-        """Add downlink ground stations to be considered by the access checker.
-
-        :meta private:
-        """
-        if self.type == "ground_station":
-            for ground_station in self.simulator.world.groundStations:
-                self.satellite.add_location_for_access_checking(
-                    object=ground_station.ModelTag,
-                    r_LP_P=np.array(ground_station.r_LP_P_Init).flatten(),
-                    min_elev=ground_station.minimumElevation,
-                    type="ground_station",
-                )
-
     def get_obs(self):
         """Iterate over property specs.
 
@@ -412,6 +398,7 @@ class OpportunityProperties(Observation):
                 n=self.n_ahead_observe,
                 filter=self.satellite.get_access_filter(),
                 types=self.type,
+                pad=True,
             )
         ):
             props = {}

--- a/src/bsk_rl/obs/observations.py
+++ b/src/bsk_rl/obs/observations.py
@@ -396,7 +396,6 @@ class OpportunityProperties(Observation):
         for i, opportunity in enumerate(
             self.satellite.find_next_opportunities(
                 n=self.n_ahead_observe,
-                filter=self.satellite.get_access_filter(),
                 types=self.type,
                 pad=True,
             )

--- a/src/bsk_rl/obs/observations.py
+++ b/src/bsk_rl/obs/observations.py
@@ -291,7 +291,7 @@ def _target_angle(sat, opp):
 class OpportunityProperties(Observation):
 
     _fn_map = {
-        "priority": lambda sat, opp: opp[opp["type"]].priority,
+        "priority": lambda sat, opp: opp["object"].priority,
         "r_LP_P": lambda sat, opp: opp["r_LP_P"],
         "opportunity_open": lambda sat, opp: opp["window"][0] - sat.simulator.sim_time,
         "opportunity_mid": lambda sat, opp: sum(opp["window"]) / 2

--- a/src/bsk_rl/sats/access_satellite.py
+++ b/src/bsk_rl/sats/access_satellite.py
@@ -54,12 +54,9 @@ class AccessSatellite(Satellite):
         self.generation_duration = generation_duration
         self.initial_generation_duration = initial_generation_duration
 
-    def reset_pre_sim_init(self) -> None:
-        """Reset satellite opportunity calculations and lists.
-
-        :meta private:
-        """
-        super().reset_pre_sim_init()
+    def reset_overwrite_previous(self) -> None:
+        """Overwrite previous opportunities and locations."""
+        super().reset_overwrite_previous()
         self.opportunities: list[dict] = []
         self.window_calculation_time = 0
         self.locations_for_access_checking: list[dict[str, Any]] = []
@@ -452,6 +449,13 @@ class ImagingSatellite(AccessSatellite):
         except AttributeError:
             return []
 
+    def reset_overwrite_previous(self) -> None:
+        """Overwrite statistics about previous episode."""
+        super().reset_overwrite_previous()
+        self._image_event_name = None
+        self.imaged = 0
+        self.missed = 0
+
     def reset_pre_sim_init(self) -> None:
         """Set the buffer parameters based on computed windows.
 
@@ -460,9 +464,6 @@ class ImagingSatellite(AccessSatellite):
         super().reset_pre_sim_init()
         self.sat_args["transmitterNumBuffers"] = len(self.known_targets)
         self.sat_args["bufferNames"] = [target.id for target in self.known_targets]
-        self._image_event_name = None
-        self.imaged = 0
-        self.missed = 0
 
     def reset_post_sim_init(self) -> None:
         """Handle initial_generation_duration setting and calculate windows.

--- a/src/bsk_rl/sats/access_satellite.py
+++ b/src/bsk_rl/sats/access_satellite.py
@@ -82,7 +82,8 @@ class AccessSatellite(Satellite):
             type: Category of opportunity target provides.
         """
         location_dict = dict(r_LP_P=r_LP_P, min_elev=min_elev, type=type)
-        location_dict[type] = object
+        location_dict[type] = object  # For backwards compatibility, prefer "object" key
+        location_dict["object"] = object
         self.locations_for_access_checking.append(location_dict)
 
     def reset_post_sim_init(self) -> None:
@@ -153,7 +154,7 @@ class AccessSatellite(Satellite):
                 )
                 for new_window in new_windows:
                     self._add_window(
-                        location[location["type"]],
+                        location["object"],
                         new_window,
                         type=location["type"],
                         r_LP_P=location["r_LP_P"],
@@ -271,14 +272,14 @@ class AccessSatellite(Satellite):
             for opportunity in self.opportunities:
                 if (
                     opportunity["type"] == type
-                    and opportunity[type] == object
+                    and opportunity["object"] == object
                     and opportunity["window"][1] == new_window[0]
                 ):
                     opportunity["window"] = (opportunity["window"][0], new_window[1])
                     return
         bisect.insort(
             self.opportunities,
-            {type: object, "window": new_window, "type": type, "r_LP_P": r_LP_P},
+            {"object": object, "window": new_window, "type": type, "r_LP_P": r_LP_P},
             key=lambda x: x["window"][1],
         )
 
@@ -314,12 +315,12 @@ class AccessSatellite(Satellite):
             type = opportunity["type"]
             if (
                 (types is None or type in types)
-                and opportunity[type] not in filter
-                and (check is None or opportunity[type] in check)
+                and opportunity["object"] not in filter
+                and (check is None or opportunity["object"] in check)
             ):
-                if opportunity[type] not in windows:
-                    windows[opportunity[type]] = []
-                windows[opportunity[type]].append(opportunity["window"])
+                if opportunity["object"] not in windows:
+                    windows[opportunity["object"]] = []
+                windows[opportunity["object"]].append(opportunity["window"])
         return windows
 
     def upcoming_opportunities_dict(
@@ -345,12 +346,12 @@ class AccessSatellite(Satellite):
             type = opportunity["type"]
             if (
                 (types is None or type in types)
-                and opportunity[type] not in filter
-                and (check is None or opportunity[type] in check)
+                and opportunity["object"] not in filter
+                and (check is None or opportunity["object"] in check)
             ):
-                if opportunity[type] not in windows:
-                    windows[opportunity[type]] = []
-                windows[opportunity[type]].append(opportunity["window"])
+                if opportunity["object"] not in windows:
+                    windows[opportunity["object"]] = []
+                windows[opportunity["object"]].append(opportunity["window"])
         return windows
 
     def next_opportunities_dict(
@@ -374,11 +375,12 @@ class AccessSatellite(Satellite):
             type = opportunity["type"]
             if (
                 (types is None or type in types)
-                and opportunity[type] not in filter
-                and (check is None or opportunity[type] in check)
+                and opportunity["object"] not in filter
+                and (check is None or opportunity["object"] in check)
             ):
-                if opportunity[type] not in next_windows:
-                    next_windows[opportunity[type]] = opportunity["window"]
+                print(opportunity)
+                if opportunity["object"] not in next_windows:
+                    next_windows[opportunity["object"]] = opportunity["window"]
         return next_windows
 
     def find_next_opportunities(
@@ -417,8 +419,8 @@ class AccessSatellite(Satellite):
                 type = opportunity["type"]
                 if (
                     (types is None or type in types)
-                    and opportunity[type] not in filter
-                    and (check is None or opportunity[type] in check)
+                    and opportunity["object"] not in filter
+                    and (check is None or opportunity["object"] in check)
                 ):
                     next_opportunities.append(opportunity)
 
@@ -494,9 +496,9 @@ class ImagingSatellite(AccessSatellite):
         """
         super().reset_pre_sim_init()
         self.sat_args["bufferNames"] = [
-            loc[loc["type"]].id
+            loc["object"].id
             for loc in self.locations_for_access_checking
-            if hasattr(loc[loc["type"]], "id")
+            if hasattr(loc["object"], "id")
         ]
 
         self.sat_args["transmitterNumBuffers"] = len(self.sat_args["bufferNames"])
@@ -564,7 +566,7 @@ class ImagingSatellite(AccessSatellite):
                 check=self.get_access_check(),
                 filter=self.get_access_filter(),
                 types="target",
-            )[-1]["target"]
+            )[-1]["object"]
         elif isinstance(target_query, Target):
             target = target_query
         elif isinstance(target_query, str):

--- a/src/bsk_rl/scene/scenario.py
+++ b/src/bsk_rl/scene/scenario.py
@@ -4,6 +4,8 @@ import logging
 from abc import ABC
 from typing import TYPE_CHECKING
 
+from bsk_rl.utils.functional import Resetable
+
 if TYPE_CHECKING:  # pragma: no cover
     from bsk_rl.data.base import Data
     from bsk_rl.sats import Satellite
@@ -11,12 +13,19 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class Scenario(ABC):
+class Scenario(ABC, Resetable):
     """Base scenario class."""
 
-    def reset_pre_sim_init(self) -> None:  # pragma: no cover
-        """Reset the scenario before initializing the simulator."""
-        pass
+    def __init__(self) -> None:
+        self.satellites: list["Satellite"]
+
+    def link_satellites(self, satellites: list["Satellite"]) -> None:
+        """Link the environment satellite list to the scenario.
+
+        Args:
+            satellites: List of satellites to communicate between.
+        """
+        self.satellites = satellites
 
     def initial_data(self, satellite: "Satellite", data_type: type["Data"]) -> "Data":
         """Furnish the :class:`~bsk_rl.data.base.DataStore` with initial data."""

--- a/src/bsk_rl/scene/targets.py
+++ b/src/bsk_rl/scene/targets.py
@@ -103,11 +103,22 @@ class UniformTargets(Scenario):
             self.n_targets = np.random.randint(self._n_targets[0], self._n_targets[1])
         logger.info(f"Generating {self.n_targets} targets")
         self.regenerate_targets()
+        for satellite in self.satellites:
+            if hasattr(satellite, "add_location_for_access_checking"):
+                for target in self.targets:
+                    satellite.add_location_for_access_checking(
+                        object=target,
+                        r_LP_P=target.r_LP_P,
+                        min_elev=satellite.sat_args_generator[
+                            "imageTargetMinimumElevation"
+                        ],  # Assume not randomized
+                        type="target",
+                    )
 
     def regenerate_targets(self) -> None:
         """Regenerate targets uniformly.
 
-        Override this method (ash demonstrated in :class:`CityTargets`) to generate
+        Override this method (as demonstrated in :class:`CityTargets`) to generate
         other distributions.
         """
         self.targets = []

--- a/src/bsk_rl/scene/targets.py
+++ b/src/bsk_rl/scene/targets.py
@@ -90,6 +90,9 @@ class UniformTargets(Scenario):
             priority_distribution = lambda: np.random.rand()  # noqa: E731
         self.priority_distribution = priority_distribution
         self.radius = radius
+
+    def reset_overwrite_previous(self) -> None:
+        """Overwrite target list from previous episode."""
         self.targets = []
 
     def reset_pre_sim_init(self) -> None:

--- a/src/bsk_rl/sim/dyn.py
+++ b/src/bsk_rl/sim/dyn.py
@@ -1142,6 +1142,14 @@ class GroundStationDynModel(ImagingDynModel):
             groundStation.addSpacecraftToModel(self.scObject.scStateOutMsg)
             self.transmitter.addAccessMsgToTransmitter(groundStation.accessOutMsgs[-1])
 
+            if hasattr(self.satellite, "add_location_for_access_checking"):
+                self.satellite.add_location_for_access_checking(
+                    object=groundStation.ModelTag,
+                    r_LP_P=np.array(groundStation.r_LP_P_Init).flatten(),
+                    min_elev=groundStation.minimumElevation,
+                    type="ground_station",
+                )
+
 
 class FullFeaturedDynModel(GroundStationDynModel, LOSCommDynModel):
     """Convenience class for a satellite with ground station and line-of-sight comms."""

--- a/src/bsk_rl/utils/functional.py
+++ b/src/bsk_rl/utils/functional.py
@@ -177,6 +177,34 @@ class AbstractClassProperty:
         )
 
 
+class Resetable:
+    """Base class for resetable objects.
+
+    This class is used to define objects that are reset at the beginning of each episode.
+    These include :class:`~bsk_rl.scene.Scenario`, :class:`~bsk_rl.data.GlobalReward`,
+    :class:`~bsk_rl.comm.CommunicationMethod`, and :class:`~bsk_rl.sats.Satellite`.
+
+    The :class:`~bsk_rl.GeneralSatelliteTasking.reset` method takes the following steps:
+
+    #. ``reset_overwrite_previous`` - Overwrite attributes from previous episode.
+    #. ``reset_pre_sim_init`` - Reset before simulator initialization.
+    #. Initialize a new Basilisk simulator.
+    #. ``reset_post_sim_init`` - Reset after simulator initialization.
+    """
+
+    def reset_overwrite_previous(self) -> None:
+        """Overwrite attributes from previous episode."""
+        pass
+
+    def reset_pre_sim_init(self) -> None:
+        """Reset before simulator initialization."""
+        pass
+
+    def reset_post_sim_init(self) -> None:
+        """Reset after simulator initialization."""
+        pass
+
+
 __doc_title__ = "Functional"
 __all__ = [
     "valid_func_name",
@@ -188,4 +216,5 @@ __all__ = [
     "check_aliveness_checkers",
     "is_property",
     "AbstractClassProperty",
+    "Resetable",
 ]

--- a/tests/integration/act/test_int_actions.py
+++ b/tests/integration/act/test_int_actions.py
@@ -57,9 +57,13 @@ class TestImagingAndDownlink:
     def test_image_by_name(self):
         # Smoketest
         self.env.reset()
-        target = self.env.unwrapped.satellite.find_next_opportunities(n=10)[9]["object"]
+        target = self.env.unwrapped.satellite.find_next_opportunities(
+            n=10, types="target"
+        )[9]["object"]
         self.env.step(target)
-        target = self.env.unwrapped.satellite.find_next_opportunities(n=10)[9]["object"]
+        target = self.env.unwrapped.satellite.find_next_opportunities(
+            n=10, types="target"
+        )[9]["object"]
         self.env.step(target.id)
         assert True
 

--- a/tests/integration/act/test_int_actions.py
+++ b/tests/integration/act/test_int_actions.py
@@ -57,9 +57,9 @@ class TestImagingAndDownlink:
     def test_image_by_name(self):
         # Smoketest
         self.env.reset()
-        target = self.env.unwrapped.satellite.find_next_opportunities(n=10)[9]["target"]
+        target = self.env.unwrapped.satellite.find_next_opportunities(n=10)[9]["object"]
         self.env.step(target)
-        target = self.env.unwrapped.satellite.find_next_opportunities(n=10)[9]["target"]
+        target = self.env.unwrapped.satellite.find_next_opportunities(n=10)[9]["object"]
         self.env.step(target.id)
         assert True
 

--- a/tests/unittest/data/test_data.py
+++ b/tests/unittest/data/test_data.py
@@ -43,7 +43,9 @@ class TestGlobalReward:
     def test_reset(self):
         GlobalReward.datastore_type = MagicMock()
         dm = GlobalReward()
+        dm.reset_overwrite_previous()
         dm.reset_pre_sim_init()
+        dm.reset_post_sim_init()
         assert dm.cum_reward == {}
 
     def test_create_data_store(self):
@@ -51,7 +53,9 @@ class TestGlobalReward:
         GlobalReward.datastore_type = MagicMock(return_value="ds")
         dm = GlobalReward()
         dm.scenario = MagicMock()
+        dm.reset_overwrite_previous()
         dm.reset_pre_sim_init()
+        dm.reset_post_sim_init()
         dm.create_data_store(sat)
         assert sat.data_store == "ds"
         assert sat.id in dm.cum_reward

--- a/tests/unittest/obs/test_observations.py
+++ b/tests/unittest/obs/test_observations.py
@@ -144,7 +144,7 @@ class TestOpportunityProperties:
         sat = MagicMock(simulator=MagicMock(sim_time=10.0))
         opp = dict(
             type="target",
-            target=MagicMock(priority=1.0),
+            object=MagicMock(priority=1.0),
             window=[20.0, 30.0],
             r_LP_P=1.0,
         )
@@ -178,13 +178,13 @@ class TestOpportunityProperties:
         ob = obs.OpportunityProperties(
             dict(prop="priority", norm=2.0),
             dict(
-                prop="double_priority", fn=lambda sat, opp: opp["target"].priority * 2.0
+                prop="double_priority", fn=lambda sat, opp: opp["object"].priority * 2.0
             ),
             n_ahead_observe=2,
         )
         ob.satellite = MagicMock()
         ob.satellite.find_next_opportunities.return_value = [
-            {"target": MagicMock(priority=1.0), "type": "target"}
+            {"object": MagicMock(priority=1.0), "type": "target"}
         ] * ob.n_ahead_observe
         assert ob.get_obs() == {
             "target_0": {"priority_normd": 0.5, "double_priority": 2.0},

--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -303,8 +303,10 @@ class TestImagingSatellite:
     @patch("bsk_rl.sats.Satellite.reset_pre_sim_init")
     def test_reset_pre_sim_init(self, mock_reset):
         sat = self.make_sat()
-        sat.data_store = MagicMock()
-        sat.data_store.data.known = [MagicMock()] * 5
+        sat.reset_overwrite_previous()
+        targets = [MagicMock()] * 5
+        for target in targets:
+            sat.add_location_for_access_checking(target, np.ones(3), 1.0, "target")
         sat.sat_args = {}
         sat.reset_pre_sim_init()
         mock_reset.assert_called_once()

--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -33,7 +33,7 @@ class TestAccessSatellite:
             object=target, r_LP_P=[0, 0, 0], min_elev=1.0, type="target"
         )
         assert (
-            dict(target=target, r_LP_P=[0, 0, 0], min_elev=1.0, type="target")
+            dict(object=target, target=target, r_LP_P=[0, 0, 0], min_elev=1.0, type="target")
             in sat.locations_for_access_checking
         )
 
@@ -81,7 +81,7 @@ class TestAccessSatellite:
             ),
         )
         sat.locations_for_access_checking = [
-            dict(target=tgt, type="target", min_elev=1.3, r_LP_P=tgt.r_LP_P)
+            dict(object=tgt, type="target", min_elev=1.3, r_LP_P=tgt.r_LP_P)
         ]
         sat.calculate_additional_windows(100.0)
         assert tgt in sat.opportunities_dict()
@@ -216,8 +216,8 @@ class TestAccessSatellite:
     def test_add_window(self, merge_time, tgt, window, expected_window):
         sat = self.make_sat()
         sat.opportunities = [
-            dict(target=self.tgt1, window=(3.0, 8.0), type="target"),
-            dict(target=self.tgt0, window=(2.0, 10.0), type="target"),
+            dict(object=self.tgt1, window=(3.0, 8.0), type="target"),
+            dict(object=self.tgt0, window=(2.0, 10.0), type="target"),
         ]
         sat._add_window(
             tgt, window, merge_time=merge_time, type="target", r_LP_P=np.zeros(3)
@@ -225,10 +225,10 @@ class TestAccessSatellite:
         assert expected_window in sat.opportunities_dict()[tgt]
 
     opportunities = [
-        dict(downlink="downObj1", window=(10, 20), type="downlink"),
-        dict(target="tgtObj1", window=(20, 30), type="target"),
-        dict(downlink="downObj1", window=(30, 40), type="downlink"),
-        dict(downlink="downObj2", window=(35, 45), type="downlink"),
+        dict(object="downObj1", window=(10, 20), type="downlink"),
+        dict(object="tgtObj1", window=(20, 30), type="target"),
+        dict(object="downObj1", window=(30, 40), type="downlink"),
+        dict(object="downObj2", window=(35, 45), type="downlink"),
     ]
 
     def test_upcoming_opportunities(self):
@@ -339,11 +339,11 @@ class TestImagingSatellite:
         tgt2: [(30.0, 40.0)],
     }
     opportunities = [
-        dict(target=tgt0, window=(0.0, 10.0), type="target"),
-        dict(target=tgt1, window=(10.0, 20.0), type="target"),
-        dict(target=tgt0, window=(20.0, 30.0), type="target"),
-        dict(target=tgt2, window=(30.0, 40.0), type="target"),
-        dict(target=tgt0, window=(40.0, 50.0), type="target"),
+        dict(object=tgt0, window=(0.0, 10.0), type="target"),
+        dict(object=tgt1, window=(10.0, 20.0), type="target"),
+        dict(object=tgt0, window=(20.0, 30.0), type="target"),
+        dict(object=tgt2, window=(30.0, 40.0), type="target"),
+        dict(object=tgt0, window=(40.0, 50.0), type="target"),
     ]
 
     @patch(
@@ -389,7 +389,7 @@ class TestImagingSatellite:
     def test_parse_target_selection(self, query, expected):
         sat = self.make_sat()
         sat.find_next_opportunities = lambda *args, **kwargs: [
-            dict(target=target) for target in self.upcoming_targets[0 : kwargs["n"]]
+            dict(object=target) for target in self.upcoming_targets[0 : kwargs["n"]]
         ]
         sat.data_store = MagicMock()
         sat.data_store.data.known = self.upcoming_targets

--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -33,7 +33,13 @@ class TestAccessSatellite:
             object=target, r_LP_P=[0, 0, 0], min_elev=1.0, type="target"
         )
         assert (
-            dict(object=target, target=target, r_LP_P=[0, 0, 0], min_elev=1.0, type="target")
+            dict(
+                object=target,
+                target=target,
+                r_LP_P=[0, 0, 0],
+                min_elev=1.0,
+                type="target",
+            )
             in sat.locations_for_access_checking
         )
 

--- a/tests/unittest/scene/test_scenario.py
+++ b/tests/unittest/scene/test_scenario.py
@@ -36,6 +36,7 @@ class TestUniformTargets:
 
     def test_reset_constant(self):
         st = UniformTargets(10)
+        st.satellites = MagicMock()
         st.regenerate_targets = MagicMock()
         st.reset_pre_sim_init()
         assert st.n_targets == 10
@@ -44,12 +45,14 @@ class TestUniformTargets:
     @pytest.mark.repeat(10)
     def test_reset_variable(self):
         st = UniformTargets((8, 10))
+        st.satellites = MagicMock()
         st.regenerate_targets = MagicMock()
         st.reset_pre_sim_init()
         assert 8 <= st.n_targets <= 10
 
     def test_regenerate_targets(self):
         st = UniformTargets(3, radius=1.0, priority_distribution=lambda: 1)
+        st.satellites = MagicMock()
         st.n_targets = st._n_targets
         st.regenerate_targets()
         assert len(st.targets) == 3
@@ -60,9 +63,11 @@ class TestUniformTargets:
     def test_regenerate_targets_repeatable(self):
         np.random.seed(0)
         st1 = UniformTargets(3, radius=1.0)
+        st1.satellites = MagicMock()
         st1.reset_pre_sim_init()
         np.random.seed(0)
         st2 = UniformTargets(3, radius=1.0)
+        st2.satellites = MagicMock()
         st2.reset_pre_sim_init()
         for t1, t2 in zip(st1.targets, st2.targets):
             assert (t1.r_LP_P == t2.r_LP_P).all()
@@ -102,6 +107,7 @@ class TestCityTargets:
         n_database = 5
         self.mock_data(mock_read_csv, n_database=n_database)
         ct = CityTargets(n_targets)
+        ct.satellites = MagicMock()
         if n_targets > n_database:
             with pytest.raises(ValueError):
                 ct.reset_pre_sim_init()
@@ -122,6 +128,7 @@ class TestCityTargets:
     ):
         self.mock_data(mock_read_csv)
         ct = CityTargets(n_targets, n_select_from=n_select_from)
+        ct.satellites = MagicMock()
         ct.reset_pre_sim_init()
         assert len(ct.targets) == n_targets
         if isinstance(n_select_from, int):
@@ -137,6 +144,7 @@ class TestCityTargets:
         self.mock_data(mock_read_csv, n_database=10)
         n_targets = 10
         ct = CityTargets(n_targets, location_offset=0.01, radius=1.0)
+        ct.satellites = MagicMock()
         ct.reset_pre_sim_init()
         for target in ct.targets:
             assert np.linalg.norm(target.r_LP_P - nominal) <= 0.03


### PR DESCRIPTION
## Description

Refactors the filter argument for access satellite to function more like the python built-in filter. As a result, makes designing and combining access filters easier.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## How Has This Been Tested?

Tests pass.

### Passes Tests
- [X] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [X] __Documentation builds__ `cd docs; make html`

### Test Configuration
- Python: 3.10
- Basilisk: 2.3.0
- Platform: MacOS

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I changed an example ipynb, I have locally rebuilt the documentation
