### PR TITLE
Issue 152: Fix logger mocking in access test

### DIFF
--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -18,10 +18,12 @@ from bsk_rl.utils.functional import valid_func_name
 @patch.multiple(sats.AccessSatellite, __abstractmethods__=set())
 class TestAccessSatellite:
     def make_sat(self):
-        return sats.AccessSatellite(
+        sat = sats.AccessSatellite(
             "TestSat",
             sat_args={"imageTargetMinimumElevation": 1},
         )
+        sat.logger = MagicMock()
+        return sat
 
     def test_add_location_for_access_checking(self):
         sat = self.make_sat()


### PR DESCRIPTION
## Description

Fixes a test that started failing recently (and should have been failing for a while) due to a logger not being initialized.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [X] __Documentation builds__ `cd docs; make html`
