### PR TITLE
Issue #153: Move initial data generation to rewarder

### DIFF
--- a/docs/source/docsRequired.txt
+++ b/docs/source/docsRequired.txt
@@ -1,1 +1,0 @@
-sphinx_rtd_theme==2.0.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,8 @@ Version 1.0.1
   initialization dependencies.
 * Replace ``get_access_filter`` with :class:`~bsk_rl.sats.AccessSatellite.add_access_filter`,
   which uses boolean functions to determine which opportunity windows to consider.
+* Changed the initial data generation to be defined in :class:`~bsk_rl.data.GlobalReward` 
+  instead of :class:`~bsk_rl.scene.Scenario`.
 
 
 Version 1.0.0

--- a/src/bsk_rl/data/__init__.py
+++ b/src/bsk_rl/data/__init__.py
@@ -18,8 +18,8 @@ with the :class:`GlobalReward.calculate_reward` method.
 The :class:`~bsk_rl.data.base.DataStore` handles each satellite's local knowledge of the
 scenario and the data it generates. The data store gains data in three ways:
 
-1. On environment reset, the :class:`~bsk_rl.scene.Scenario` calls
-   :class:`~bsk_rl.scene.Scenario.initial_data` to provide the initial knowledge of the
+1. On environment reset, the :class:`~bsk_rl.data.GlobalReward` calls
+   :class:`~bsk_rl.data.GlobalReward.initial_data` to provide the initial knowledge of the
    scenario for each satellite. This may be empty or may contain some a priori knowledge,
    such as a list of targets that are desired to be imaged.
 2. At the end of each step, the result of :class:`~bsk_rl.data.base.DataStore.get_log_state`

--- a/src/bsk_rl/data/base.py
+++ b/src/bsk_rl/data/base.py
@@ -50,7 +50,7 @@ class DataStore(ABC):
         Args:
             satellite: Satellite which data is being stored for.
             initial_data: Initial data to start the store with. Usually comes from
-                :class:`~bsk_rl.scene.Scenario.initial_data`.
+                :class:`~bsk_rl.data.GlobalReward.initial_data`.
         """
         self.satellite = satellite
         self.staged_data = []
@@ -141,6 +141,10 @@ class GlobalReward(ABC, Resetable):
         self.data = self.data_type()
         self.cum_reward = {}
 
+    def initial_data(self, satellite: "Satellite") -> "Data":
+        """Furnish the :class:`~bsk_rl.data.base.DataStore` with initial data."""
+        return self.data_type()
+
     def create_data_store(self, satellite: "Satellite") -> None:
         """Create a data store for a satellite.
 
@@ -148,8 +152,7 @@ class GlobalReward(ABC, Resetable):
             satellite: Satellite to create a data store for.
         """
         satellite.data_store = self.datastore_type(
-            satellite,
-            initial_data=self.scenario.initial_data(satellite, self.data_type),
+            satellite, initial_data=self.initial_data(satellite)
         )
         self.cum_reward[satellite.id] = 0.0
 

--- a/src/bsk_rl/data/unique_image_data.py
+++ b/src/bsk_rl/data/unique_image_data.py
@@ -139,6 +139,14 @@ class UniqueImageReward(GlobalReward):
         super().__init__()
         self.reward_fn = reward_fn
 
+    def initial_data(self, satellite: "Satellite") -> "UniqueImageData":
+        """Furnish data to the scenario.
+
+        Currently, it is assumed that all targets are known a priori, so the initial data
+        given to the data store is the list of all targets.
+        """
+        return self.data_type(known=self.scenario.targets)
+
     def create_data_store(self, satellite: "Satellite") -> None:
         """Override the access filter in addition to creating the data store."""
         super().create_data_store(satellite)

--- a/src/bsk_rl/scene/scenario.py
+++ b/src/bsk_rl/scene/scenario.py
@@ -27,10 +27,6 @@ class Scenario(ABC, Resetable):
         """
         self.satellites = satellites
 
-    def initial_data(self, satellite: "Satellite", data_type: type["Data"]) -> "Data":
-        """Furnish the :class:`~bsk_rl.data.base.DataStore` with initial data."""
-        return data_type()
-
 
 class UniformNadirScanning(Scenario):
     """Defines a nadir target center at the center of the planet."""

--- a/src/bsk_rl/scene/targets.py
+++ b/src/bsk_rl/scene/targets.py
@@ -129,17 +129,6 @@ class UniformTargets(Scenario):
                 Target(name=f"tgt-{i}", r_LP_P=x, priority=self.priority_distribution())
             )
 
-    def initial_data(self, satellite: "Satellite", data_type: type["Data"]) -> "Data":
-        """Furnish data to the scenario.
-
-        Currently, it is assumed that all targets are known a priori, so the initial data
-        given to the data store is the list of all targets.
-        """
-        try:
-            return data_type(known=self.targets)
-        except TypeError:
-            return data_type()
-
 
 class CityTargets(UniformTargets):
     """Environment with targets distributed around population centers."""


### PR DESCRIPTION
## Description
Closes #153

Small change to move initial data generation to be defined with rest of data system instead of scenario.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [X] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [X] __Documentation builds__ `cd docs; make html`

### Test Configuration
- Python: 3.10
- Basilisk: 3.2
- Platform: Mac

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I changed an example ipynb, I have locally rebuilt the documentation
