### PR TITLE
Change name ID and fix satellite deaths

### DIFF
--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -352,6 +352,8 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
             if action is not None:
                 satellite.requires_retasking = False
                 satellite.set_action(action)
+            if not satellite.is_alive():
+                satellite.requires_retasking = False
             else:
                 if satellite.requires_retasking:
                     logger.warning(

--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -89,6 +89,10 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
         if isinstance(satellites, Satellite):
             satellites = [satellites]
         self.satellites = satellites
+        sat_names = [satellite.name for satellite in self.satellites]
+        if len(sat_names) != len(set(sat_names)):
+            for satellite in self.satellites:
+                satellite.nonunique_name = True
         self.simulator: Simulator
 
         if scenario is None:

--- a/src/bsk_rl/sats/satellite.py
+++ b/src/bsk_rl/sats/satellite.py
@@ -90,6 +90,7 @@ class Satellite(ABC, Resetable):
                 will stop the simulation.
         """
         self.name = name
+        self.nonunique_name = False
         self.logger = logging.getLogger(__name__).getChild(self.name)
         if sat_args is None:
             sat_args = self.default_sat_args()
@@ -107,7 +108,10 @@ class Satellite(ABC, Resetable):
     @property
     def id(self) -> str:
         """Unique human-readable identifier."""
-        return f"{self.name}_{id(self)}"
+        if self.nonunique_name:
+            return f"{self.name}_{id(self)}"
+        else:
+            return self.name
 
     def _generate_sat_args(self) -> None:
         """Instantiate sat_args from any randomizers in provided sat_args."""

--- a/src/bsk_rl/utils/functional.py
+++ b/src/bsk_rl/utils/functional.py
@@ -121,7 +121,7 @@ def aliveness_checker(func: Callable[..., bool]) -> Callable[..., bool]:
         self = args[0]
         alive = func(*args, **kwargs)
         if not alive and log_failure:
-            self.satellite.log_info(f"failed {func.__name__} check")
+            self.satellite.log_warning(f"failed {func.__name__} check")
         return alive
 
     inner.__doc__ = (

--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -301,10 +301,12 @@ def test_init(mock_init):
 @patch.multiple(sats.ImagingSatellite, __abstractmethods__=set())
 class TestImagingSatellite:
     def make_sat(self):
-        return sats.ImagingSatellite(
+        sat = sats.ImagingSatellite(
             "TestSat",
             sat_args={"imageTargetMinimumElevation": 1},
         )
+        sat.nonunique_name = False
+        return sat
 
     @patch("bsk_rl.sats.Satellite.reset_pre_sim_init")
     def test_reset_pre_sim_init(self, mock_reset):

--- a/tests/unittest/sats/test_satellite.py
+++ b/tests/unittest/sats/test_satellite.py
@@ -42,6 +42,7 @@ class TestSatellite:
     def test_id(self):
         sat1 = sats.Satellite(name="TestSat", sat_args={})
         sat2 = sats.Satellite(name="TestSat", sat_args={})
+        sat1.nonunique_name = sat2.nonunique_name = True
         assert sat1.id != sat2.id
         assert sat1.id.startswith("TestSat")
 
@@ -75,6 +76,7 @@ class TestSatellite:
     def test_satellite_command(self):
         sat1 = sats.Satellite(name="TestSat", sat_args={})
         sat2 = sats.Satellite(name="TestSat", sat_args={})
+        sat1.nonunique_name = sat2.nonunique_name = True
         self.satellites = [sat1, sat2]
         assert sat1 == eval(sat1._satellite_command)
         assert sat1 != eval(sat2._satellite_command)

--- a/tests/unittest/sats/test_satellite.py
+++ b/tests/unittest/sats/test_satellite.py
@@ -64,14 +64,20 @@ class TestSatellite:
     #     assert sat._timed_terminal_event_name is None
 
     @pytest.mark.parametrize(
-        "dyn_state,fsw_state",
-        [(False, False), (False, True), (True, False), (True, True)],
+        "dyn_state,fsw_state,sat_past_is_alive",
+        [
+            (a, b, c)
+            for a in [True, False]
+            for b in [True, False]
+            for c in [True, False]
+        ],
     )
-    def test_is_alive(self, dyn_state, fsw_state):
+    def test_is_alive(self, dyn_state, fsw_state, sat_past_is_alive):
         sat = sats.Satellite(name="TestSat", sat_args={})
+        sat._is_alive = sat_past_is_alive
         sat.dynamics = MagicMock(is_alive=MagicMock(return_value=dyn_state))
         sat.fsw = MagicMock(is_alive=MagicMock(return_value=fsw_state))
-        assert sat.is_alive() == (dyn_state and fsw_state)
+        assert sat.is_alive() == (dyn_state and fsw_state and sat_past_is_alive)
 
     def test_satellite_command(self):
         sat1 = sats.Satellite(name="TestSat", sat_args={})

--- a/tests/unittest/test_gym_env.py
+++ b/tests/unittest/test_gym_env.py
@@ -262,6 +262,8 @@ class TestSatelliteTasking:
     )
     def test_init(self):
         mock_sat = Satellite("sat", {})
+        mock_sat.nonunique_name = False
+        mock_sat.name = "sat"
         env = SatelliteTasking(
             satellite=mock_sat,
             world_type=MagicMock(),
@@ -326,6 +328,7 @@ class TestConstellationTasking:
         mock_sat_2 = MagicMock()
         mock_sat_1.sat_args_generator = {}
         mock_sat_2.sat_args_generator = {}
+        mock_sat_1.name = mock_sat_2.name = "SomeSat"
         mock_data = MagicMock(scenario=None)
         env = ConstellationTasking(
             satellites=[mock_sat_1, mock_sat_2],
@@ -333,6 +336,7 @@ class TestConstellationTasking:
             scenario=MagicMock(),
             rewarder=mock_data,
         )
+        assert mock_sat_1.nonunique_name
         env.unwrapped.world_args_generator = {"utc_init": "a long time ago"}
         env.communicator = MagicMock()
         obs, info = env.reset()

--- a/tests/unittest/utils/test_functional.py
+++ b/tests/unittest/utils/test_functional.py
@@ -123,8 +123,9 @@ class TestAlivenessChecker:
         d.simulator.sim_time = 0
         d.satellite.info = []
         d.satellite.id = "SAT"
+        d.satellite._is_alive
         assert functional.check_aliveness_checkers(d, log_failure=True) is False
-        d.satellite.log_info.assert_called_with("failed is_living check")
+        d.satellite.log_warning.assert_called_with("failed is_living check")
 
 
 @pytest.mark.parametrize("prop_name,expected", [("prop", True), ("not_a_prop", False)])


### PR DESCRIPTION
## Description
Closes #157 
Closes #158 

Two separate changes.
1) make it so that satellite names include a numeric ID only in the case of conflicts
2) keep satellites dead once they have died

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## How Has This Been Tested?

### Passes Tests
- [X] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [X] __Documentation builds__ `cd docs; make html`

### Test Configuration
- Python: 3.11
- Basilisk: 3.2
- Platform: MacOS

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I changed an example ipynb, I have locally rebuilt the documentation
