### PR TITLE
Issue #170: Eliminate deprecated BSK messaging import

### DIFF
--- a/src/bsk_rl/sim/fsw.py
+++ b/src/bsk_rl/sim/fsw.py
@@ -36,7 +36,6 @@ from functools import wraps
 from typing import TYPE_CHECKING, Callable, Iterable, Optional
 from weakref import proxy
 
-import Basilisk.architecture.cMsgCInterfacePy as cMsgPy
 import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (
@@ -284,8 +283,8 @@ class BasicFSWModel(FSWModel):
 
     def _set_gateway_msgs(self) -> None:
         """Create C-wrapped gateway messages."""
-        self.attRefMsg = cMsgPy.AttRefMsg_C()
-        self.attGuidMsg = cMsgPy.AttGuidMsg_C()
+        self.attRefMsg = messaging.AttRefMsg_C()
+        self.attGuidMsg = messaging.AttGuidMsg_C()
 
         self._zero_gateway_msgs()
 
@@ -344,7 +343,7 @@ class BasicFSWModel(FSWModel):
                 self.fsw.world.ephemConverter.ephemOutMsgs[self.fsw.world.sun_index]
             )
             self.sunPoint.useBoresightRateDamping = 1
-            cMsgPy.AttGuidMsg_C_addAuthor(
+            messaging.AttGuidMsg_C_addAuthor(
                 self.sunPoint.attGuidOutMsg, self.fsw.attGuidMsg
             )
 
@@ -381,7 +380,7 @@ class BasicFSWModel(FSWModel):
             self.hillPoint.celBodyInMsg.subscribeTo(
                 self.fsw.world.ephemConverter.ephemOutMsgs[self.fsw.world.body_index]
             )
-            cMsgPy.AttRefMsg_C_addAuthor(
+            messaging.AttRefMsg_C_addAuthor(
                 self.hillPoint.attRefOutMsg, self.fsw.attRefMsg
             )
 
@@ -543,7 +542,7 @@ class BasicFSWModel(FSWModel):
                 self.fsw.dynamics.simpleNavObject.attOutMsg
             )
             self.trackingError.attRefInMsg.subscribeTo(self.fsw.attRefMsg)
-            cMsgPy.AttGuidMsg_C_addAuthor(
+            messaging.AttGuidMsg_C_addAuthor(
                 self.trackingError.attGuidOutMsg, self.fsw.attGuidMsg
             )
 
@@ -689,7 +688,7 @@ class ImagingFSWModel(BasicFSWModel):
                 self.fsw.dynamics.imagingTarget.currentGroundStateOutMsg
             )
             self.locPoint.useBoresightRateDamping = 1
-            cMsgPy.AttGuidMsg_C_addAuthor(
+            messaging.AttGuidMsg_C_addAuthor(
                 self.locPoint.attGuidOutMsg, self.fsw.attGuidMsg
             )
 
@@ -832,7 +831,7 @@ class ContinuousImagingFSWModel(ImagingFSWModel):
 
         def reset_for_action(self) -> None:
             """Reset scanning controller."""
-            self.instMsg = cMsgPy.DeviceCmdMsg_C()
+            self.instMsg = messaging.DeviceCmdMsg_C()
             self.instMsg.write(messaging.DeviceCmdMsgPayload())
             self.fsw.dynamics.instrument.nodeStatusInMsg.subscribeTo(self.instMsg)
             return super().reset_for_action()


### PR DESCRIPTION
## Description
Part of #170

Don't use the old messaging import in Python

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

### Passes Tests
- [X] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [X] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [X] __Documentation builds__ `cd docs; make html`

### Test Configuration
- Python: 3.10
- Basilisk: 2.3.29
- Platform: MacOS

# Checklist:

- [X] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I changed an example ipynb, I have locally rebuilt the documentation
