### PR TITLE
Issue #172: Change default solar panel direction

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,8 @@ Version 1.0.1
 * Add ability to correlate ``sat_args`` between satellites with the ``sat_arg_randomizer``
   option in :class:`~bsk_rl.GeneralSatelliteTasking`.  This is demonstrated in the setup
   of a constellation in the `multiagent example <examples/multiagent_envs.ipynb>`_.
+* The default solar panel normal direction is now the negative z-axis, which is antiparallel
+  to the default instrument direction.
 
 
 Version 1.0.0

--- a/src/bsk_rl/sim/dyn.py
+++ b/src/bsk_rl/sim/dyn.py
@@ -560,7 +560,7 @@ class BasicDynamicsModel(DynamicsModel):
     @default_args(
         panelArea=2 * 1.0 * 0.5,
         panelEfficiency=0.20,
-        nHat_B=np.array([0, 1, 0]),
+        nHat_B=np.array([0, 0, -1]),
     )
     def setup_solar_panel(
         self,


### PR DESCRIPTION
## Description
Closes #172

Changes the default solar panel direction to be antiparallel to the default instrument direction.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

### Passes Tests
- [ ] __Unit tests__ `pytest --cov bsk_rl --cov-report term-missing tests/unittest`
- [ ] __Integrated tests__ `pytest --cov bsk_rl --cov-report term-missing tests/integration`
- [ ] __Documentation builds__ `cd docs; make html`

### Test Configuration
- Python:
- Basilisk:
- Platform: 

# Checklist:

- [ ] My code follows the style guidelines of this project (passes Black, ruff, and isort)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and release notes
- [ ] Commit messages are atomic, are in the form `Issue #XXX: Message` and have a useful message
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I changed an example ipynb, I have locally rebuilt the documentation
