### PR TITLE
Issue #203: Warning if initial battery or buffer initial levels are inadequate

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,6 +24,7 @@ Development Version
   opportunity than ``target``. Also allows for access filters to include an opportunity
   type.
 * Improve performance of :class:`~bsk_rl.obs.Eclipse` observations by about 95%.
+* Logs a warning if the initial battery charge or buffer level is incompatible with its capacity.
 
 
 

--- a/src/bsk_rl/sim/dyn.py
+++ b/src/bsk_rl/sim/dyn.py
@@ -635,7 +635,7 @@ class BasicDynamicsModel(DynamicsModel):
         if storedCharge_Init > batteryStorageCapacity or storedCharge_Init < 0:
             self.logger.warning(
                 f"Battery initial charge {storedCharge_Init} incompatible with its capacity {batteryStorageCapacity}."
-                )
+            )
         self.powerMonitor.storedCharge_Init = storedCharge_Init
         self.powerMonitor.addPowerNodeToModel(self.solarPanel.nodePowerOutMsg)
         self.simulator.AddModelToTask(
@@ -952,6 +952,10 @@ class ImagingDynModel(BasicDynamicsModel):
                 self.storageUnit.addPartition(buffer_name)
 
         if storageInit != 0:
+            if storageInit > dataStorageCapacity or storageInit < 0:
+                self.logger.warning(
+                    f"Initial storage level {storageInit} incompatible with its capacity {dataStorageCapacity}."
+                )
             self.storageUnit.setDataBuffer(["STORED DATA"], [int(storageInit)])
 
         # Add the storage unit to the transmitter
@@ -1091,6 +1095,10 @@ class ContinuousImagingDynModel(ImagingDynModel):
         self.storageUnit.addDataNodeToModel(self.instrument.nodeDataOutMsg)
         self.storageUnit.addDataNodeToModel(self.transmitter.nodeDataOutMsg)
         self.storageUnitValidCheck = storageUnitValidCheck
+        if storageInit > dataStorageCapacity or storageInit < 0:
+            self.logger.warning(
+                f"Initial storage level {storageInit} incompatible with its capacity {dataStorageCapacity}."
+            )
         self.storageUnit.setDataBuffer(storageInit)
 
         # Add the storage unit to the transmitter

--- a/src/bsk_rl/sim/dyn.py
+++ b/src/bsk_rl/sim/dyn.py
@@ -632,6 +632,10 @@ class BasicDynamicsModel(DynamicsModel):
         self.powerMonitor = simpleBattery.SimpleBattery()
         self.powerMonitor.ModelTag = "powerMonitor"
         self.powerMonitor.storageCapacity = batteryStorageCapacity
+        if storedCharge_Init > batteryStorageCapacity or storedCharge_Init < 0:
+            self.logger.warning(
+                f"Battery initial charge {storedCharge_Init} incompatible with its capacity {batteryStorageCapacity}."
+                )
         self.powerMonitor.storedCharge_Init = storedCharge_Init
         self.powerMonitor.addPowerNodeToModel(self.solarPanel.nodePowerOutMsg)
         self.simulator.AddModelToTask(


### PR DESCRIPTION
## Description
Closes #203 

Passing an initial battery charge or buffer level incompatible with the maximum capacity leads to initialization with a full battery or zero buffer level. Now, it creates a warning indicating that this is occurring. 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Unit tests were created to check if the warning was being correctly generated.

## Future Work

None.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I changed an example ipynb, I have locally rebuilt the documentation
