### PR TITLE
Issue #0: More granularity on reset timing

### DIFF
--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -281,6 +281,12 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
             time_limit=self.time_limit,
         )
 
+        self.scenario.reset_during_sim_init()
+        self.rewarder.reset_during_sim_init()
+        self.communicator.reset_during_sim_init()
+
+        self.simulator.finish_init()
+
         self.scenario.reset_post_sim_init()
         self.rewarder.reset_post_sim_init()
         self.communicator.reset_post_sim_init()

--- a/src/bsk_rl/sim/simulator.py
+++ b/src/bsk_rl/sim/simulator.py
@@ -57,6 +57,8 @@ class Simulator(SimulationBaseClass.SimBaseClass):
             self.dynamics_list[satellite.name] = satellite.set_dynamics(self.sim_rate)
             self.fsw_list[satellite.name] = satellite.set_fsw(self.sim_rate)
 
+    def finish_init(self) -> None:
+        """Finish simulator initialization."""
         self.InitializeSimulation()
         self.ConfigureStopTime(0)
         self.ExecuteSimulation()

--- a/src/bsk_rl/utils/functional.py
+++ b/src/bsk_rl/utils/functional.py
@@ -200,6 +200,10 @@ class Resetable:
         """Reset before simulator initialization."""
         pass
 
+    def reset_during_sim_init(self) -> None:
+        """Reset after simulator models have been created but before the simulator is initialized."""
+        pass
+
     def reset_post_sim_init(self) -> None:
         """Reset after simulator initialization."""
         pass


### PR DESCRIPTION
## Description

Allows things to be done before the simulator is executed for the first time but after basilisk module have been created.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Passes tests

## Future Work

None

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I changed an example ipynb, I have locally rebuilt the documentation
