### PR TITLE
[#265] Maximum range checking model

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -29,6 +29,8 @@ Development - |version|
 * Allow for the ``time_limit`` to be randomized.
 * Added observation for arbitrary relative states between two satellites in :class:`~bsk_rl.obs.RelativeProperties`.
 * Allow for the ``transmitterPacketSize`` to be specified. The default sets it to the instrument's baud rate.
+* Add a maximum range checking dynamics model in :class:`~bsk_rl.dynamics.MaxRangeDynModel`. Useful for keeping an agent
+  in the vicinity of a target early in training.
 
 
 Version 1.1.0

--- a/src/bsk_rl/sats/satellite.py
+++ b/src/bsk_rl/sats/satellite.py
@@ -282,10 +282,7 @@ class Satellite(ABC, Resetable):
     @property
     def _satellite_command(self) -> str:
         """Generate string that refers to self in simBase."""
-        return (
-            "[satellite for satellite in self.satellites "
-            + f"if satellite.name=='{self.name}'][0]"
-        )
+        return f"self.get_satellite('{self.name}')"
 
     def _info_command(self, info: str) -> str:
         """Generate command to log to info from an event.

--- a/src/bsk_rl/sim/simulator.py
+++ b/src/bsk_rl/sim/simulator.py
@@ -162,6 +162,20 @@ class Simulator(SimulationBaseClass.SimBaseClass):
         self.eventList.remove(event)
         del self.eventMap[event_name]
 
+    def get_satellite(self, name: str) -> "Satellite":
+        """Get a satellite by name.
+
+        Args:
+            name: Name of the satellite to retrieve.
+
+        Returns:
+            The satellite object with the specified name.
+        """
+        for sat in self.satellites:
+            if sat.name == name:
+                return sat
+        raise ValueError(f"Satellite with name '{name}' not found.")
+
     def __del__(self):
         """Log when simulator is deleted."""
         logger.debug("Basilisk simulator deleted")

--- a/tests/unittest/sats/test_satellite.py
+++ b/tests/unittest/sats/test_satellite.py
@@ -1,9 +1,11 @@
+from functools import partial
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
 from bsk_rl import sats
+from bsk_rl.sim import Simulator
 from bsk_rl.sim.fsw import Task
 
 
@@ -110,6 +112,7 @@ class TestSatellite:
         sat1 = sats.Satellite(name="TestSat_1", sat_args={})
         sat2 = sats.Satellite(name="TestSat_2", sat_args={})
         self.satellites = [sat1, sat2]
+        self.get_satellite = partial(Simulator.get_satellite, self)
         assert sat1 == eval(sat1._satellite_command)
         assert sat1 != eval(sat2._satellite_command)
         assert sat2 == eval(sat2._satellite_command)


### PR DESCRIPTION
## Description
Closes #265 

Adds a max range checking feature to force a deputy to stay within a radius of a chief.

Also refactors indexing satellites from the simulator.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Added integrated test.

## Future Work

Potential to extend to multiple satellites, but probably not needed.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
