### PR TITLE
[MINOR] Fix issue with failure penalty in multiagent env

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -33,6 +33,8 @@ Development - |version|
 * Add a maximum range checking dynamics model in :class:`MaxRangeDynModel`. Useful for keeping an agent
   in the vicinity of a target early in training.
 * Add properties in spacecraft dynamics for orbital element observations.
+* Fix an issue with failure penalties in the PettingZoo environment when the rewarder
+  does not return a reward for a satellite.
 
 
 Version 1.1.0

--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -671,7 +671,10 @@ class ConstellationTasking(
         reward = deepcopy(self.reward_dict)
         for agent, satellite in zip(self.possible_agents, self.satellites):
             if not satellite.is_alive():
-                reward[agent] += self.failure_penalty
+                if agent in reward:
+                    reward[agent] += self.failure_penalty
+                else:
+                    reward[agent] = self.failure_penalty
 
         reward_keys = list(reward.keys())
         for agent in reward_keys:


### PR DESCRIPTION
## Description

Fix an issue with failure penalties in the PettingZoo environment when the rewarder does not return a reward for a satellite.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Added test to cover this case.

## Future Work

None.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
