### PR TITLE
[#144] Correct noncircular orbit generation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -38,6 +38,9 @@ Development - |version|
 * Allow for per-episode randomization of :class:`ResourceReward` weights and observation
   of those weights with :class:`ResourceRewardWeight`.
 * Add :class:`ImpulsiveThrustHill` for impulsive thrust in the Hill frame.
+* Separate :class:`random_circular_orbit` and :class:`random_orbit` to avoid misleading
+  altitude argument.
+
 
 Version 1.1.0
 -------------

--- a/tests/integration/act/test_int_actions_discrete.py
+++ b/tests/integration/act/test_int_actions_discrete.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import gymnasium as gym
 import numpy as np
 from pytest import approx
@@ -5,7 +7,7 @@ from pytest import approx
 from bsk_rl import act, data, obs, sats
 from bsk_rl.scene import UniformNadirScanning, UniformTargets
 from bsk_rl.sim import dyn, fsw
-from bsk_rl.utils.orbital import random_orbit
+from bsk_rl.utils.orbital import random_circular_orbit, random_orbit
 
 #########################
 # Composed Action Tests #
@@ -86,7 +88,7 @@ class TestChargingAction:
             "Charger",
             sat_args=ChargeSat.default_sat_args(
                 # High, inclined orbit makes eclipse unlikely
-                oe=random_orbit(alt=50000, i=90),
+                oe=random_orbit(a=50000, i=90),
                 batteryStorageCapacity=500_000,
                 storedCharge_Init=250_000,
             ),
@@ -119,7 +121,7 @@ class TestDesatAction:
             satellite=self.DesatSat(
                 "Ellite",
                 sat_args=self.DesatSat.default_sat_args(
-                    oe=random_orbit,
+                    oe=partial(random_circular_orbit, i=45),
                     wheelSpeeds=[1000.0, -1000.0, 1000.0],
                     nHat_B=np.array([0, 1, 0]),
                 ),

--- a/tests/integration/obs/test_int_observations.py
+++ b/tests/integration/obs/test_int_observations.py
@@ -71,9 +71,7 @@ class TestSatProperties:
         "SatelliteTasking-v1",
         satellite=SatPropertiesSat(
             "Sputnik",
-            sat_args=SatPropertiesSat.default_sat_args(
-                oe=random_orbit(r_body=7000, alt=0, i=45)
-            ),
+            sat_args=SatPropertiesSat.default_sat_args(oe=random_orbit(a=7000, i=45)),
         ),
         scenario=UniformTargets(n_targets=0),
         rewarder=data.NoReward(),

--- a/tests/integration/obs/test_int_relative_observations.py
+++ b/tests/integration/obs/test_int_relative_observations.py
@@ -28,17 +28,13 @@ class TestRelProperties:
             RelPropertiesSat(
                 "Deputy",
                 sat_args=dict(
-                    oe=random_orbit(
-                        i=1.0, alt=1000.0, e=0.0, Omega=0.0, omega=0.0, f=0.0
-                    )
+                    oe=random_orbit(i=1.0, a=7000.0, e=0.0, Omega=0.0, omega=0.0, f=0.0)
                 ),
             ),
             BasicSat(
                 "Chief",
                 sat_args=dict(
-                    oe=random_orbit(
-                        i=1.0, alt=1100.0, e=0.0, Omega=0.0, omega=0.0, f=0.0
-                    )
+                    oe=random_orbit(i=1.0, a=7100.0, e=0.0, Omega=0.0, omega=0.0, f=0.0)
                 ),
             ),
         ],

--- a/tests/unittest/utils/test_orbital.py
+++ b/tests/unittest/utils/test_orbital.py
@@ -17,6 +17,13 @@ class TestRandomOrbit:
         assert 0 <= oe.omega <= 2 * np.pi
         assert 0 <= oe.f <= 2 * np.pi
 
+    @pytest.mark.repeat(10)
+    def test_random_circular_orbit(self):
+        oe = orbital.random_circular_orbit(i=None, Omega=None, f=None)
+        assert -np.pi <= oe.i <= np.pi
+        assert 0 <= oe.Omega <= 2 * np.pi
+        assert 0 <= oe.f <= 2 * np.pi
+
     def test_repeatable(self):
         np.random.seed(0)
         oe1 = orbital.random_orbit()
@@ -25,9 +32,7 @@ class TestRandomOrbit:
         assert oe1.f == oe2.f
 
     def test_units(self):
-        oe = orbital.random_orbit(
-            i=90.0, alt=500, r_body=1000, e=0.1, Omega=90.0, omega=90.0, f=90.0
-        )
+        oe = orbital.random_orbit(i=90.0, a=1500, e=0.1, Omega=90.0, omega=90.0, f=90.0)
         assert oe.a == 1500000
         assert oe.e == 0.1
         assert np.pi / 2 == oe.i == oe.Omega == oe.omega == oe.f
@@ -198,7 +203,7 @@ class TestTrajectorySimulator:
     def test_no_eclipse(self):
         ts = orbital.TrajectorySimulator(
             self.epoch,
-            oe=orbital.random_orbit(alt=50000, i=90.0, omega=0, Omega=0, f=45.0),
+            oe=orbital.random_orbit(a=50000, i=90.0, omega=0, Omega=0, f=45.0),
             mu=self.mu,
         )
         assert ts.next_eclipse(0, max_tries=3) == (1.0, 1.0)


### PR DESCRIPTION
## Description

Separate :class:`random_circular_orbit` and :class:`random_orbit` to avoid misleading
  altitude argument.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [x] By commit
- [ ] All changes at once

## How Has This Been Tested?

Updated tests.


## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
