### PR TITLE
[#125] Add maximum duration to imaging action

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -44,6 +44,7 @@ Development - |version|
   :class:`~bsk_rl.scene.RSOPoints`, :class:`~bsk_rl.sim.fsw.RSOInspectorFSWModel`, and
   :class:`~bsk_rl.sim.dyn.RSODynModel`. An example environment setup is described in the
   `RSO Inspection <examples/rso_inspection.ipynb>`_ example.
+* Add a maximum duration option to :class:`~bsk_rl.act.Image`.
 
 
 Version 1.1.0

--- a/src/bsk_rl/gym.py
+++ b/src/bsk_rl/gym.py
@@ -86,7 +86,8 @@ class GeneralSatelliteTasking(Env, Generic[SatObs, SatAct]):
             sim_rate: [s] Rate for model simulation.
             max_step_duration: [s] Maximum time to propagate sim at a step. If
                 satellites are using variable interval actions, the actual step duration
-                will be less than or equal to this value.
+                will be less than or equal to this value. It is preferable to set durations
+                in the actions themselves.
             failure_penalty: Reward for satellite failure. Should be nonpositive.
             time_limit: [s] Time at which to truncate the simulation. Can also be a function
                 that takes no arguments and returns a float. This function will be called

--- a/tests/unittest/act/test_actions.py
+++ b/tests/unittest/act/test_actions.py
@@ -111,7 +111,9 @@ class TestImage:
         image.satellite = MagicMock()
         image.satellite.parse_target_selection.return_value = self.target
         out = image.image(5, None)
-        image.satellite.task_target_for_imaging.assert_called_once_with(self.target)
+        image.satellite.task_target_for_imaging.assert_called_once_with(
+            self.target, max_duration=None
+        )
         assert out == "target_1"
 
     def test_image_retask(self):
@@ -119,7 +121,19 @@ class TestImage:
         image.satellite = MagicMock()
         image.satellite.parse_target_selection.return_value = self.target
         out = image.image(5, "target_1")
-        image.satellite.enable_target_window.assert_called_once_with(self.target)
+        image.satellite.enable_target_window.assert_called_once_with(
+            self.target, max_duration=None
+        )
+        assert out == "target_1"
+
+    def test_image_max_duration(self):
+        image = act.Image(n_ahead_image=10, max_duration=100.0)
+        image.satellite = MagicMock()
+        image.satellite.parse_target_selection.return_value = self.target
+        out = image.image(5, None)
+        image.satellite.task_target_for_imaging.assert_called_once_with(
+            self.target, max_duration=100.0
+        )
         assert out == "target_1"
 
     def test_set_action(self):


### PR DESCRIPTION
## Description
Closes #125

Best way of addressing this, just have all actions keep track of what duration they want to be. `max_step_duration` should be more of a safeguard than anything.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Added and fixed tests.

## Future Work

None.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
