### PR TITLE
Feature/two way range check

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -51,6 +51,8 @@ Development - |version|
   overwritten.
 * Add the ability to define metaagents that concatenate satellite action and observation
   spaces in the environment.
+* Add the ability to have the chief also terminate if a deputy violates a maximum range
+  constraint in :class:`~bsk_rl.sim.dyn.MaxRangeDynModel`.
 
 
 Version 1.1.0

--- a/src/bsk_rl/sim/simulator.py
+++ b/src/bsk_rl/sim/simulator.py
@@ -66,8 +66,7 @@ class Simulator(SimulationBaseClass.SimBaseClass):
         """Finish simulator initialization."""
         self.set_vizard_epoch()
         self.InitializeSimulation()
-        self.ConfigureStopTime(0)
-        self.ExecuteSimulation()
+        self.TotalSim.StepUntilStop(0, -1)
 
     @property
     def sim_time_ns(self) -> int:


### PR DESCRIPTION
## Description
Closes #298 
Closes #300

Adds `enforce_range_on_chief` option to `MaxRangeDynModel` to cause the chief to also be terminated if the deputy dies.

Also fixes an issue exposed in tests where bad behavior would happen if a satellite died at t=0.


### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## How Has This Been Tested?

Updated tests.

## Future Work

None.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
