### PR TITLE
Avoid bad RLlib logs on init

### DIFF
--- a/src/bsk_rl/utils/rllib/callbacks.py
+++ b/src/bsk_rl/utils/rllib/callbacks.py
@@ -185,6 +185,7 @@ class EpisodeDataLogger:
         self.metrics_logger = None
         self.env: "GeneralSatelliteTasking"
         self.satellites: list["Satellite"]
+        self.logs_to_skip = 3  # Hacky way to avoid a log on initial reset
 
     def set_metrics_logger(self, metrics_logger):
         """Set the metrics logger for this environment."""
@@ -216,7 +217,10 @@ class EpisodeDataLogger:
 
     def reset(self, **kwargs):
         """Log data before resetting the environment."""
-        self.log_data_on_reset()
+        if self.logs_to_skip > 0:
+            self.logs_to_skip -= 1
+        else:
+            self.log_data_on_reset()
         return self.env.reset(**kwargs)
 
 


### PR DESCRIPTION
## Description

RLlib logging wrapper logs some weird data immediately after starting RLlib. This code avoids those logs. I don't love this code, but it's better than nothing.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

RLlib code not covered by tests.

## Future Work

None.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
