### PR TITLE
Settable collision check rate

### DIFF
--- a/src/bsk_rl/sim/simulator.py
+++ b/src/bsk_rl/sim/simulator.py
@@ -183,7 +183,9 @@ class Simulator(SimulationBaseClass.SimBaseClass):
             actionFunction=lambda sim: sim.logger.info("Max step duration reached"),
             terminal=True,
         )
-        self.ConfigureStopTime(mc.sec2nano(min(self.time_limit, 2**31)))
+        self.ConfigureStopTime(
+            mc.sec2nano(min(self.time_limit, 2**31)), StopCondition=">="
+        )
         self.ExecuteSimulation()
 
     def delete_event(self, event_name) -> None:

--- a/tests/unittest/sim/test_simulator.py
+++ b/tests/unittest/sim/test_simulator.py
@@ -65,4 +65,6 @@ class TestSimulator:
         sim = self.mock_sim(max_step_duration=step_duration, time_limit=time_limit)
         sim.TotalSim.CurrentNanos = start_time * 1000000000
         sim.run()
-        sim.ConfigureStopTime.assert_called_with(time_limit * 1000000000)
+        sim.ConfigureStopTime.assert_called_with(
+            time_limit * 1000000000, StopCondition=">="
+        )


### PR DESCRIPTION
## Description

Allows for collisions to be checked for at a different rate than the sim. Helpful if you know motion is slow relative to the sim rate.

Also uses the new basilisk stop condition for better behavior.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [X] By commit
- [ ] All changes at once

## Future Work

Do other things need configurable rates?

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
