### PR TITLE
Update illumination factor convention

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,9 @@ Development - |version|
   or :class:`~bsk_rl.sim.dyn.BasicDynModel`. These are lighter-weight base classes that lack
   some functionality that was not always wanted.
 * Update support data import paths to allow compatibility with Basilisk's new dataFetcher API.
+* Standardize RSO inspection/eclipse naming from ``shadow`` to ``illumination``.
+  Custom code should update ``min_shadow_factor`` to ``min_illumination_factor`` and
+  ``shadowFactor`` to ``illuminationFactor`` where these names are referenced.
 
   .. warning::
 

--- a/src/bsk_rl/scene/rso_points.py
+++ b/src/bsk_rl/scene/rso_points.py
@@ -6,7 +6,7 @@ etc.). Implemented geometries include:
 
 * :class:`SphericalRSO`: Points are generated on a sphere using the Fibonacci sphere method.
 
-This module does not consider self-shadowing effects or inspector to RSO shadowing effects.
+This module does not consider self-occlusion effects or inspector-to-RSO occlusion effects.
 """
 
 import logging
@@ -37,7 +37,7 @@ class RSOPoint:
     theta_max: float
     range_max: float
     theta_solar_max: float
-    min_shadow_factor: float
+    min_illumination_factor: float
 
     def __hash__(self) -> int:
         """Hash target by unique id."""
@@ -52,7 +52,7 @@ class RSOPoint:
                 self.theta_max,
                 self.range_max,
                 self.theta_solar_max,
-                self.min_shadow_factor,
+                self.min_illumination_factor,
             )
         )
 
@@ -105,7 +105,7 @@ class RSOPoints(Scenario):
                 point.theta_max,
                 point.range_max,
                 point.theta_solar_max,
-                point.min_shadow_factor,
+                point.min_illumination_factor,
             )
             # Add point to each inspector
             for inspector in self.inspectors:
@@ -167,7 +167,7 @@ class SphericalRSO(RSOPoints):
         theta_max: float = np.radians(45),
         range_max: float = -1,
         theta_solar_max: float = np.radians(60),
-        min_shadow_factor: float = 0.1,
+        min_illumination_factor: float = 0.1,
     ):
         """Generate points on a sphere using the Fibonacci sphere method.
 
@@ -177,14 +177,14 @@ class SphericalRSO(RSOPoints):
             theta_max: [rad] Maximum angle from the normal for inspection.
             range_max: [m] Maximum range for inspection.
             theta_solar_max: [rad] Minimum solar incidence angle for illumination.
-            min_shadow_factor: Minimum shadow factor for imaging.
+            min_illumination_factor: Minimum illumination factor for imaging.
         """
         self.n_points = n_points
         self.radius = radius
         self.theta_max = theta_max
         self.range_max = range_max
         self.theta_solar_max = theta_solar_max
-        self.min_shadow_factor = min_shadow_factor
+        self.min_illumination_factor = min_illumination_factor
 
     def generate_points(self) -> list[RSOPoint]:
         """Generate a list of RSOPoint objects on a sphere."""
@@ -200,7 +200,7 @@ class SphericalRSO(RSOPoints):
                     self.theta_max,
                     self.range_max,
                     self.theta_solar_max,
-                    self.min_shadow_factor,
+                    self.min_illumination_factor,
                 )
             )
 

--- a/src/bsk_rl/sim/dyn/rso_inspection.py
+++ b/src/bsk_rl/sim/dyn/rso_inspection.py
@@ -35,7 +35,7 @@ class RSODynModel(EclipseDynModel, DynamicsModel):
         theta: float,
         range: float,
         theta_solar: float,
-        min_shadow_factor: float,
+        min_illumination_factor: float,
     ):
         """Add a point on the RSO for observation.
 
@@ -45,7 +45,7 @@ class RSODynModel(EclipseDynModel, DynamicsModel):
             theta: [rad] Max angle from instrument to normal.
             range: [m] Max range to point for imaging.
             theta_solar: [rad] Maximum solar incidence angle for illumination.
-            min_shadow_factor: [-] Minimum shadow factor for imaging.
+            min_illumination_factor: [-] Minimum illumination factor for imaging.
         """
         rso_point_model = spacecraftLocation.SpacecraftLocation()
         rso_point_model.primaryScStateInMsg.subscribeTo(self.scObject.scStateOutMsg)
@@ -67,7 +67,7 @@ class RSODynModel(EclipseDynModel, DynamicsModel):
         rso_point_model.aHat_B = aHat_B
         rso_point_model.theta = theta
         rso_point_model.theta_solar = theta_solar
-        rso_point_model.min_shadow_factor = min_shadow_factor
+        rso_point_model.min_illumination_factor = min_illumination_factor
         rso_point_model.maximumRange = range
         self.simulator.AddModelToTask(
             self.rso_task_name, rso_point_model, ModelPriority=1

--- a/src/bsk_rl/utils/orbital.py
+++ b/src/bsk_rl/utils/orbital.py
@@ -457,7 +457,7 @@ class TrajectorySimulator(SimulationBaseClass.SimBaseClass):
         self.AddModelToTask(simTaskName, self.planet_state_log)
         self._J20002Pfix_log = []
         self.AddModelToTask(simTaskName, self.eclipse_log)
-        self._shadowFactor_log = []
+        self._illuminationFactor_log = []
 
         self.InitializeSimulation()
 
@@ -484,7 +484,7 @@ class TrajectorySimulator(SimulationBaseClass.SimBaseClass):
         self._time_log.extend(self.sc_state_log.times())
         self._r_BN_N_log.extend(self.sc_state_log.r_BN_N)
         self._J20002Pfix_log.extend(self.planet_state_log.J20002Pfix)
-        self._shadowFactor_log.extend(self.eclipse_log.shadowFactor)
+        self._illuminationFactor_log.extend(self.eclipse_log.illuminationFactor)
         self.sc_state_log.clear()
         self.planet_state_log.clear()
         self.eclipse_log.clear()
@@ -493,7 +493,10 @@ class TrajectorySimulator(SimulationBaseClass.SimBaseClass):
         self.extend_to(t + self.dt)
         upcoming_times = self.times[self.times > self._eclipse_search_time]
         upcoming_eclipse = (
-            np.array(self._shadowFactor_log)[self.times > self._eclipse_search_time] > 0
+            np.array(self._illuminationFactor_log)[
+                self.times > self._eclipse_search_time
+            ]
+            > 0
         ).astype(float)
         for i in np.where(np.diff(upcoming_eclipse) == -1)[0]:
             self._eclipse_starts.append(upcoming_times[i])


### PR DESCRIPTION
## Description
Closes #<issue-number>

This PR standardizes naming from shadow-based terms to illumination-based terms in the RSO inspection/eclipsing paths.

### Summary
- Renamed remaining internal usage to illumination naming:
  - `min_illumination_factor`
  - `illuminationFactor`
- Updated wording in RSO points module docs from shadowing to occlusion terminology.
- No intended behavior change; this is a naming/consistency cleanup.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [x] All changes at once

## How Has This Been Tested?

- `git grep -n -E "shadowFactor|min_shadow_factor|shadow_factor" src/bsk_rl tests/unittest` (no matches)
- `.venv/bin/python -m py_compile src/bsk_rl/scene/rso_points.py src/bsk_rl/sim/dyn/rso_inspection.py src/bsk_rl/utils/orbital.py`
- Verified Basilisk fields exist in this environment (`min_illumination_factor` and `illuminationFactor`).

Note: full pytest execution in this sandbox is still blocked by local pandas binary policy.

## Future Work

N/A

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and release notes
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

