### PR TITLE
[#205] Keep opportunities sorted when merging windows

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,10 @@ Development - |version|
 -----------------------
 .. *Release Date: MMM. DD, YYYY*
 
+* Fix a bug where extending an access opportunity window across a generation seam
+  could leave the satellite's ``opportunities`` list out of close-time order, which
+  corrupted ``bisect``-based opportunity lookups. See issue #205.
+
 Version 1.3.0
 -------------
 *Release Date: May. 19, 2026*

--- a/src/bsk_rl/sats/access_satellite.py
+++ b/src/bsk_rl/sats/access_satellite.py
@@ -288,7 +288,7 @@ class AccessSatellite(Satellite):
                 check all windows for merges.
         """
         if new_window[0] == merge_time or merge_time is None:
-            for opportunity in self.opportunities:
+            for i, opportunity in enumerate(self.opportunities):
                 if (
                     opportunity["type"] == type
                     and opportunity["object"] == object
@@ -296,8 +296,11 @@ class AccessSatellite(Satellite):
                 ):
                     # Extending the close time changes the opportunity's sort
                     # position, so re-insert it to keep opportunities ordered by
-                    # close time (see issue #205).
-                    self.opportunities.remove(opportunity)
+                    # close time (see issue #205). Remove by index rather than
+                    # value: opportunity dicts hold r_LP_P as a numpy array, so
+                    # list.remove would compare arrays and raise on their
+                    # ambiguous truth value.
+                    del self.opportunities[i]
                     opportunity["window"] = (opportunity["window"][0], new_window[1])
                     bisect.insort(
                         self.opportunities,

--- a/src/bsk_rl/sats/access_satellite.py
+++ b/src/bsk_rl/sats/access_satellite.py
@@ -294,7 +294,16 @@ class AccessSatellite(Satellite):
                     and opportunity["object"] == object
                     and opportunity["window"][1] == new_window[0]
                 ):
+                    # Extending the close time changes the opportunity's sort
+                    # position, so re-insert it to keep opportunities ordered by
+                    # close time (see issue #205).
+                    self.opportunities.remove(opportunity)
                     opportunity["window"] = (opportunity["window"][0], new_window[1])
+                    bisect.insort(
+                        self.opportunities,
+                        opportunity,
+                        key=lambda x: x["window"][1],
+                    )
                     return
         bisect.insort(
             self.opportunities,

--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -237,6 +237,31 @@ class TestAccessSatellite:
         )
         assert expected_window in sat.opportunities_dict()[tgt]
 
+    def test_add_window_merge_keeps_sorted(self):
+        # Regression test for issue #205: extending a window across a generation
+        # seam via the merge path must keep opportunities sorted by close time.
+        sat = self.make_sat()
+        # Segment 1 left tgt0 truncated at the seam (close time 30).
+        sat.opportunities = [
+            dict(object=self.tgt0, window=(5.0, 30.0), type="target"),
+        ]
+        # Segment 2 generates windows starting at the seam (merge_time=30).
+        # Insert opportunities that close after the seam but before tgt0's
+        # true close time, then extend tgt0 across the seam.
+        sat._add_window(
+            self.tgt1, (31.0, 35.0), merge_time=30.0, type="target", r_LP_P=np.zeros(3)
+        )
+        sat._add_window(
+            self.tgt2, (33.0, 40.0), merge_time=30.0, type="target", r_LP_P=np.zeros(3)
+        )
+        sat._add_window(
+            self.tgt0, (30.0, 50.0), merge_time=30.0, type="target", r_LP_P=np.zeros(3)
+        )
+        close_times = [opp["window"][1] for opp in sat.opportunities]
+        assert close_times == sorted(close_times)
+        # The merge still extends the original tgt0 window rather than duplicating it.
+        assert sat.opportunities_dict()[self.tgt0] == [(5.0, 50.0)]
+
     opportunities = [
         dict(object="downObj1", window=(10, 20), type="downlink"),
         dict(object="tgtObj1", window=(20, 30), type="target"),

--- a/tests/unittest/sats/test_access_satellite.py
+++ b/tests/unittest/sats/test_access_satellite.py
@@ -241,9 +241,15 @@ class TestAccessSatellite:
         # Regression test for issue #205: extending a window across a generation
         # seam via the merge path must keep opportunities sorted by close time.
         sat = self.make_sat()
-        # Segment 1 left tgt0 truncated at the seam (close time 30).
+        # Segment 1 left tgt0 truncated at the seam (close time 30). Seed with
+        # r_LP_P as a numpy array to match how _add_window stores opportunities.
         sat.opportunities = [
-            dict(object=self.tgt0, window=(5.0, 30.0), type="target"),
+            dict(
+                object=self.tgt0,
+                window=(5.0, 30.0),
+                type="target",
+                r_LP_P=np.zeros(3),
+            ),
         ]
         # Segment 2 generates windows starting at the seam (merge_time=30).
         # Insert opportunities that close after the seam but before tgt0's


### PR DESCRIPTION
Fixes #205.

## Root cause

`AccessSatellite._add_window` has two paths: the normal `bisect.insort` insert (keeps order) and a merge path that extends a window truncated at a generation seam. The merge path mutated the opportunity's close time in place, so the extended window kept its old (smaller-key) position and any windows closing between the seam and the true end were left out of order -- exactly the behavior described in #205. `upcoming_opportunities` runs `bisect.bisect_left` on `self.opportunities`, which is only valid on a list sorted by close time, so the broken invariant silently corrupts opportunity lookups.

## Fix

In the merge branch: remove the opportunity, extend its close time, and re-insert with `bisect.insort(..., key=lambda x: x["window"][1])` -- the same primitive and key the normal insert path already uses. No new imports; nothing else touched.

## Test

Added `test_add_window_merge_keeps_sorted` to the existing `TestAccessSatellite` class (reusing its fixtures/mocks). It plays the two-segment seam scenario: without the fix the close-time list comes out `[50.0, 35.0, 40.0]`; with it, `[35.0, 40.0, 50.0]`, and the merge still produces a single extended `(5.0, 50.0)` window rather than a duplicate.

ruff/isort clean on the touched files.