### PR TITLE
Bugfix/update np2EigenVectorXd import path

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Development - |version|
   adding a new network architecture and example heuristics.
 * Add a CI smoke test that builds and steps each benchmark environment. See issue #340.
 * Update files for compatibility with Ruff 0.16.0's new default lint rules, excluding C408.
+* Update ``np2EigenMatrix3d`` and ``np2EigenVectorXd`` import path to prevent deprecation warning while preserving compatibility with older versions of Basilisk.
 
 Version 1.3.0
 -------------

--- a/src/bsk_rl/sim/dyn/base.py
+++ b/src/bsk_rl/sim/dyn/base.py
@@ -18,8 +18,12 @@ from Basilisk.utilities import (
     RigidBodyKinematics,
     macros,
     orbitalMotion,
-    unitTestSupport,
 )
+
+try:
+    from Basilisk.utilities.simHelpers import np2EigenMatrix3d, np2EigenVectorXd
+except ImportError:
+    from Basilisk.utilities.unitTestSupport import np2EigenMatrix3d, np2EigenVectorXd
 
 from bsk_rl.sim import world
 from bsk_rl.utils import actuator_primitives as aP
@@ -327,13 +331,13 @@ class DynamicsModel(DynamicsModelABC):
         self.I_mat = [Ixx, 0.0, 0.0, 0.0, Iyy, 0.0, 0.0, 0.0, Izz]
 
         self.scObject.hub.mHub = mass  # kg
-        self.scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(self.I_mat)
+        self.scObject.hub.IHubPntBc_B = np2EigenMatrix3d(self.I_mat)
 
         # Set the initial attitude and position
         self.scObject.hub.sigma_BNInit = sigma_init
         self.scObject.hub.omega_BN_BInit = omega_init
-        self.scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)
-        self.scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)
+        self.scObject.hub.r_CN_NInit = np2EigenVectorXd(rN)
+        self.scObject.hub.v_CN_NInit = np2EigenVectorXd(vN)
 
         self.simulator.AddModelToTask(
             self.task_name, self.scObject, ModelPriority=priority
@@ -698,7 +702,7 @@ class BasicDynamicsModel(
             self.world.gravFactory.spiceObject.planetStateOutMsgs[self.world.sun_index]
         )
         self.solarPanel.setPanelParameters(
-            unitTestSupport.np2EigenVectorXd(nHat_B),
+            np2EigenVectorXd(nHat_B),
             panelArea,
             panelEfficiency,
         )


### PR DESCRIPTION
## Description
Closes #348 

Updates import path for `np2EigenVectorXd` and `np2EigenMatrix3d` to prevent deprecation warning while preserving backwards compatibility.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [ x] All changes at once

## How Has This Been Tested?

Passed unit and integration tests.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
