### PR TITLE
[#337] Allow continuous aliveness checkers

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,8 @@ Development - |version|
 * Add a CI smoke test that builds and steps each benchmark environment. See issue #340.
 * Update files for compatibility with Ruff 0.16.0's new default lint rules, excluding C408.
 * Update ``np2EigenMatrix3d`` and ``np2EigenVectorXd`` import path to prevent deprecation warning while preserving compatibility with older versions of Basilisk.
+* Allow :func:`~bsk_rl.utils.functional.aliveness_checker` to run as a continuous Basilisk
+  event that interrupts the environment step on failure. See issue #337.
 
 Version 1.3.0
 -------------

--- a/src/bsk_rl/sats/satellite.py
+++ b/src/bsk_rl/sats/satellite.py
@@ -281,14 +281,14 @@ class Satellite(ABC, Resetable):
                     def condition(sim, checker=checker):
                         return not checker()
 
-                    def side_effect(sim, checker=checker):
-                        checker(log_failure=True)
+                    def side_effect(sim, name=name):
+                        self.logger.warning(f"failed {name} check")
                         self._is_alive = False
                         self.record_death(sim.sim_time)
 
                     self.simulator.createNewEvent(
                         valid_func_name(
-                            f"aliveness_{self.name}_{type(model).__name__}_{name}"
+                            f"aliveness_{self.name}_{model.__class__.__name__}_{name}"
                         ),
                         macros.sec2nano(check_rate),
                         True,

--- a/src/bsk_rl/sats/satellite.py
+++ b/src/bsk_rl/sats/satellite.py
@@ -20,6 +20,7 @@ from bsk_rl.utils.functional import (
     Resetable,
     collect_default_args,
     compose_types,
+    is_property,
     safe_dict_merge,
     valid_func_name,
 )
@@ -257,6 +258,45 @@ class Satellite(ABC, Resetable):
         fsw = self.fsw_type(self, fsw_rate, **self.sat_args)
         self.fsw = proxy(fsw)
         return fsw
+
+    def setup_aliveness_events(self) -> None:
+        """Create simulator events for continuous aliveness checkers.
+
+        :meta private:
+        """
+        for model in (self.dynamics, self.fsw):
+            for name in dir(model):
+                if (
+                    not name.startswith("__")
+                    and not is_property(model, name)
+                    and callable(getattr(model, name))
+                    and hasattr(getattr(model, name), "is_aliveness_checker")
+                    and getattr(getattr(model, name), "continuous", False)
+                ):
+                    checker = getattr(model, name)
+                    check_rate = checker.check_rate
+                    if check_rate is None:
+                        check_rate = self.simulator.sim_rate
+
+                    def condition(sim, checker=checker):
+                        return not checker()
+
+                    def side_effect(sim, checker=checker):
+                        checker(log_failure=True)
+                        self._is_alive = False
+                        self.record_death(sim.sim_time)
+
+                    self.simulator.createNewEvent(
+                        valid_func_name(
+                            f"aliveness_{self.name}_{type(model).__name__}_{name}"
+                        ),
+                        macros.sec2nano(check_rate),
+                        True,
+                        conditionFunction=condition,
+                        actionFunction=side_effect,
+                        terminal=True,
+                        exactRateMatch=False,
+                    )
 
     def reset_during_sim_init(self) -> None:
         """Called during environment reset, during Basilisk simulation initialization."""

--- a/src/bsk_rl/sim/dyn/__init__.py
+++ b/src/bsk_rl/sim/dyn/__init__.py
@@ -31,8 +31,10 @@ Aliveness Checking
 ------------------
 
 Certain functions in the dynamics model are decorated with the :func:`~bsk_rl.utils.functional.aliveness_checker`
-decorator. These functions are called at each step to check if the satellite is still
-operational, returning true if the satellite is still alive.
+decorator. These functions are called at each environment step to check if the satellite
+is still operational, returning true if the satellite is still alive. Passing
+``continuous=True`` to the decorator also evaluates the checker during integration and
+stops the environment step if it fails.
 
 """
 

--- a/src/bsk_rl/sim/fsw/__init__.py
+++ b/src/bsk_rl/sim/fsw/__init__.py
@@ -25,8 +25,10 @@ Aliveness Checking
 ------------------
 
 Certain functions in the FSW models are decorated with the :func:`~bsk_rl.utils.functional.aliveness_checker`
-decorator. These functions are called at each step to check if the satellite is still
-operational, returning true if the satellite is still alive.
+decorator. These functions are called at each environment step to check if the satellite
+is still operational, returning true if the satellite is still alive. Passing
+``continuous=True`` to the decorator also evaluates the checker during integration and
+stops the environment step if it fails.
 """
 
 from bsk_rl.sim.fsw.base import (

--- a/src/bsk_rl/sim/simulator.py
+++ b/src/bsk_rl/sim/simulator.py
@@ -62,6 +62,7 @@ class Simulator(SimulationBaseClass.SimBaseClass):
             satellite.set_simulator(self)
             self.dynamics_list[satellite.name] = satellite.set_dynamics(self.sim_rate)
             self.fsw_list[satellite.name] = satellite.set_fsw(self.sim_rate)
+            satellite.setup_aliveness_events()
 
     def finish_init(self) -> None:
         """Finish simulator initialization."""

--- a/src/bsk_rl/utils/functional.py
+++ b/src/bsk_rl/utils/functional.py
@@ -5,7 +5,7 @@ import warnings
 from copy import deepcopy
 from functools import wraps
 from types import new_class
-from typing import Any, Callable, ParamSpec, TypeVar
+from typing import Any, Callable, Optional, ParamSpec, TypeVar
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -115,23 +115,41 @@ def vectorize_nested_dict(dictionary: dict) -> tuple[list[str], np.ndarray]:
     return list(np.concatenate(keys)), np.concatenate(values)
 
 
-def aliveness_checker(func: Callable[..., bool]) -> Callable[..., bool]:
-    """Decorate function to evaluate when checking for satellite aliveness."""
+def aliveness_checker(
+    func: Optional[Callable[..., bool]] = None,
+    *,
+    continuous: bool = False,
+    check_rate: Optional[float] = None,
+) -> Callable:
+    """Decorate function to evaluate when checking for satellite aliveness.
 
-    @wraps(func)
-    def inner(*args, log_failure=False, **kwargs) -> bool:
-        self = args[0]
-        alive = func(*args, **kwargs)
-        if not alive and log_failure:
-            self.satellite.logger.warning(f"failed {func.__name__} check")
-        return alive
+    Checkers are evaluated at environment steps. Set ``continuous=True`` to also
+    evaluate the checker during integration via a Basilisk event that terminates
+    the environment step on failure. ``check_rate`` (seconds) sets how often a
+    continuous checker is evaluated and defaults to the simulator rate.
+    """
 
-    inner.__doc__ = (
-        "*Decorated with* :class:`~bsk_rl.utils.functional.aliveness_checker`\n\n"
-        + str(func.__doc__)
-    )
-    inner.is_aliveness_checker = True
-    return inner
+    def decorator(func: Callable[..., bool]) -> Callable[..., bool]:
+        @wraps(func)
+        def inner(*args, log_failure=False, **kwargs) -> bool:
+            self = args[0]
+            alive = func(*args, **kwargs)
+            if not alive and log_failure:
+                self.satellite.logger.warning(f"failed {func.__name__} check")
+            return alive
+
+        inner.__doc__ = (
+            "*Decorated with* :class:`~bsk_rl.utils.functional.aliveness_checker`\n\n"
+            + str(func.__doc__)
+        )
+        inner.is_aliveness_checker = True
+        inner.continuous = continuous
+        inner.check_rate = check_rate
+        return inner
+
+    if func is None:
+        return decorator
+    return decorator(func)
 
 
 def check_aliveness_checkers(model: Any, log_failure=False) -> bool:

--- a/src/bsk_rl/utils/functional.py
+++ b/src/bsk_rl/utils/functional.py
@@ -176,7 +176,7 @@ def check_aliveness_checkers(model: Any, log_failure=False) -> bool:
 
 def is_property(obj: Any, attr_name: str) -> bool:
     """Check if obj has an ``@property`` called ``attr_name`` without calling it."""
-    cls = type(obj)
+    cls = obj.__class__
     attribute = getattr(cls, attr_name, None)
     return attribute is not None and isinstance(attribute, property)
 

--- a/tests/integration/sim/test_int_dynamics.py
+++ b/tests/integration/sim/test_int_dynamics.py
@@ -5,6 +5,7 @@ import pytest
 
 from bsk_rl import act, data, obs, sats, scene
 from bsk_rl.sim import dyn, fsw
+from bsk_rl.utils.functional import aliveness_checker
 from bsk_rl.utils.orbital import random_orbit
 
 
@@ -240,3 +241,34 @@ class TestMaxRangeDynModel:
             assert sat2.dynamics.out_of_ranges == []
             assert not terminated["Chief"]
             assert not terminated["Deputy"]
+
+
+class TestContinuousAlivenessChecker:
+    @pytest.mark.parametrize("continuous,expected_time", [(False, 100.0), (True, 5.0)])
+    def test_step_vs_continuous(self, continuous, expected_time):
+        class BoomDyn(dyn.DynamicsModel):
+            @aliveness_checker(continuous=continuous)
+            def time_valid(self):
+                return self.simulator.sim_time < 5.0
+
+        class BoomSat(sats.Satellite):
+            fsw_type = fsw.FSWModel
+            dyn_type = BoomDyn
+            observation_spec: ClassVar[list[obs.Observation]] = [obs.Time()]
+            action_spec: ClassVar[list[act.Action]] = [act.Drift()]
+
+        env = gym.make(
+            "SatelliteTasking-v1",
+            satellite=BoomSat("Boom", sat_args=dict(oe=random_orbit)),
+            sim_rate=1.0,
+            time_limit=100.0,
+            max_step_duration=100.0,
+            disable_env_checker=True,
+        )
+
+        env.reset()
+        _, _, terminated, _, _ = env.step(0)
+
+        assert env.unwrapped.simulator.sim_time == pytest.approx(expected_time)
+        assert not env.unwrapped.satellite.is_alive()
+        assert terminated

--- a/tests/unittest/sats/test_satellite.py
+++ b/tests/unittest/sats/test_satellite.py
@@ -3,10 +3,12 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from Basilisk.utilities import macros
 
 from bsk_rl import sats
 from bsk_rl.sim import Simulator
 from bsk_rl.sim.fsw import Task
+from bsk_rl.utils import functional
 
 
 class MockDynType:
@@ -142,6 +144,57 @@ class TestSatellite:
 
     def test_update_timed_terminal_event(self):
         pass  # Probably better with integration testing
+
+    def test_setup_aliveness_events(self):
+        sat = sats.Satellite(name="TestSat", sat_args={})
+        sat._is_alive = True
+        sat.time_of_death = None
+        sat.simulator = MagicMock(sim_rate=1.0, sim_time=12.0)
+
+        class Dyn:
+            def __init__(self, satellite):
+                self.satellite = satellite
+                self.fail_continuous = False
+
+            @functional.aliveness_checker
+            def step_valid(self):
+                return True
+
+            @functional.aliveness_checker(continuous=True, check_rate=0.25)
+            def continuous_valid(self):
+                return not self.fail_continuous
+
+        class Fsw:
+            def __init__(self, satellite):
+                self.satellite = satellite
+
+            @functional.aliveness_checker(continuous=True)
+            def fsw_valid(self):
+                return True
+
+        sat.dynamics = Dyn(sat)
+        sat.fsw = Fsw(sat)
+        sat.setup_aliveness_events()
+
+        assert sat.simulator.createNewEvent.call_count == 2
+        event_names = [
+            call.args[0] for call in sat.simulator.createNewEvent.call_args_list
+        ]
+        assert any("continuous_valid" in name for name in event_names)
+        assert any("fsw_valid" in name for name in event_names)
+
+        dyn_call = sat.simulator.createNewEvent.call_args_list[0]
+        assert "continuous_valid" in dyn_call.args[0]
+        assert dyn_call.args[1] == macros.sec2nano(0.25)
+        assert dyn_call.kwargs["terminal"] is True
+        assert dyn_call.kwargs["exactRateMatch"] is False
+
+        assert dyn_call.kwargs["conditionFunction"](sat.simulator) is False
+        sat.dynamics.fail_continuous = True
+        assert dyn_call.kwargs["conditionFunction"](sat.simulator) is True
+        dyn_call.kwargs["actionFunction"](sat.simulator)
+        assert sat._is_alive is False
+        assert sat.time_of_death == 12.0
 
     def test_disable_timed_event(self):
         sat = sats.Satellite(name="TestSat", sat_args={})

--- a/tests/unittest/sats/test_satellite.py
+++ b/tests/unittest/sats/test_satellite.py
@@ -1,5 +1,6 @@
 from functools import partial
 from unittest.mock import MagicMock, patch
+from weakref import proxy
 
 import numpy as np
 import pytest
@@ -156,6 +157,10 @@ class TestSatellite:
                 self.satellite = satellite
                 self.fail_continuous = False
 
+            @property
+            def should_not_run(self):
+                raise RuntimeError("property should not be accessed")
+
             @functional.aliveness_checker
             def step_valid(self):
                 return True
@@ -172,16 +177,19 @@ class TestSatellite:
             def fsw_valid(self):
                 return True
 
-        sat.dynamics = Dyn(sat)
-        sat.fsw = Fsw(sat)
+        dyn = Dyn(sat)
+        fsw = Fsw(sat)
+        sat.dynamics = proxy(dyn)
+        sat.fsw = proxy(fsw)
         sat.setup_aliveness_events()
 
         assert sat.simulator.createNewEvent.call_count == 2
         event_names = [
             call.args[0] for call in sat.simulator.createNewEvent.call_args_list
         ]
-        assert any("continuous_valid" in name for name in event_names)
-        assert any("fsw_valid" in name for name in event_names)
+        assert any("continuous_valid" in name and "Dyn" in name for name in event_names)
+        assert any("fsw_valid" in name and "Fsw" in name for name in event_names)
+        assert not any("ProxyType" in name for name in event_names)
 
         dyn_call = sat.simulator.createNewEvent.call_args_list[0]
         assert "continuous_valid" in dyn_call.args[0]

--- a/tests/unittest/utils/test_functional.py
+++ b/tests/unittest/utils/test_functional.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from weakref import proxy
 
 import numpy as np
 import pytest
@@ -155,3 +156,4 @@ def test_is_property(prop_name, expected):
 
     c = Class()
     assert functional.is_property(c, prop_name) == expected
+    assert functional.is_property(proxy(c), prop_name) == expected

--- a/tests/unittest/utils/test_functional.py
+++ b/tests/unittest/utils/test_functional.py
@@ -125,6 +125,22 @@ class TestAlivenessChecker:
         assert functional.check_aliveness_checkers(d, log_failure=True) is False
         d.satellite.logger.warning.assert_called_with("failed is_living check")
 
+    def test_continuous_defaults(self):
+        a = self.Alive()
+        assert a.is_alive.continuous is False
+        assert a.is_alive.check_rate is None
+
+    def test_continuous_kwargs(self):
+        class Continuous:
+            @functional.aliveness_checker(continuous=True, check_rate=0.5)
+            def still_alive(self):
+                return True
+
+        c = Continuous()
+        assert c.still_alive.continuous is True
+        assert c.still_alive.check_rate == 0.5
+        assert c.still_alive()
+
 
 @pytest.mark.parametrize("prop_name,expected", [("prop", True), ("not_a_prop", False)])
 def test_is_property(prop_name, expected):


### PR DESCRIPTION
## Description
Closes #337 
Closes #59

Adds a `continuous` option to `@aliveness_checker` so checkers can run as Basilisk events and stop the environment step when they fail. Existing checkers are unchanged.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How should this pull request be reviewed?
- [ ] By commit
- [X] All changes at once

## How Has This Been Tested?

Unit tests for the decorator and event setup. Integration test comparing step-level vs continuous interruption.

## Future Work

Built-in checkers (battery, altitude, RW speed, etc.) still only run at environment steps.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and release notes
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works